### PR TITLE
Protect core views with login_required decorator

### DIFF
--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -3,7 +3,9 @@ from .tasks import task_listview, update_task_status, update_task_person, update
 from .projects import project_listview, project_detailview
 from .meetings import meeting_listview, meeting_detailview
 from django.shortcuts import render
+from .helpers import login_required
 
+@login_required
 def home(request):
     return render(request, "core/home.html")
 

--- a/otto-ui/core/views/helpers.py
+++ b/otto-ui/core/views/helpers.py
@@ -1,0 +1,17 @@
+from functools import wraps
+from django.shortcuts import redirect
+
+
+def login_required(func):
+    """Ensure the user is logged in.
+
+    If the session does not contain a ``user`` entry, redirect to ``/login/``.
+    """
+
+    @wraps(func)
+    def wrapper(request, *args, **kwargs):
+        if not request.session.get("user"):
+            return redirect("/login/")
+        return func(request, *args, **kwargs)
+
+    return wrapper

--- a/otto-ui/core/views/meetings.py
+++ b/otto-ui/core/views/meetings.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render
+from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
 from core.const import mandanten_liste
 import os
@@ -14,6 +15,7 @@ OTTO_API_KEY = os.getenv("OTTO_API_KEY")
 OTTO_API_URL = os.getenv("OTTO_API_URL")
 
 
+@login_required
 def meeting_listview(request):
     res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = res.json() if res.status_code == 200 else []
@@ -31,6 +33,7 @@ def meeting_listview(request):
     return render(request, "core/meeting_listview.html", {"meetings": filtered})
 
 
+@login_required
 @csrf_exempt
 def meeting_detailview(request, meeting_id):
     meeting_res = requests.get(f"{OTTO_API_URL}/meetings/{meeting_id}", headers={"x-api-key": OTTO_API_KEY})

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from django.http import JsonResponse
 from django.shortcuts import render
+from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
 from core.const import status_liste, prio_liste
 import os
@@ -14,6 +15,7 @@ OTTO_API_KEY = os.getenv("OTTO_API_KEY")
 OTTO_API_URL = os.getenv("OTTO_API_URL")
 
 
+@login_required
 def project_listview(request):
     res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = res.json() if res.status_code == 200 else []
@@ -32,6 +34,7 @@ def project_listview(request):
     })
 
 
+@login_required
 @csrf_exempt
 def project_detailview(request, project_id):
     if request.method == "POST":

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
+from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
 from core.const import prio_liste
 import os
@@ -14,6 +15,7 @@ OTTO_API_KEY = os.getenv("OTTO_API_KEY")
 OTTO_API_URL = os.getenv("OTTO_API_URL")
 
 
+@login_required
 def task_listview(request):
     res = requests.get(f"{OTTO_API_URL}/tasks", headers={"x-api-key": OTTO_API_KEY})
     tasks = res.json() if res.status_code == 200 else []
@@ -46,6 +48,7 @@ def task_listview(request):
     })
 
 
+@login_required
 @csrf_exempt
 def update_task_status(request):
     if request.method == "POST":
@@ -65,6 +68,7 @@ def update_task_status(request):
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
 
 
+@login_required
 @csrf_exempt
 def update_task_person(request):
     if request.method == "POST":
@@ -84,6 +88,7 @@ def update_task_person(request):
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
 
 
+@login_required
 @csrf_exempt
 def update_task_details(request):
     if request.method == "POST":
@@ -110,6 +115,7 @@ def update_task_details(request):
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
 
 
+@login_required
 @csrf_exempt
 def delete_task(request):
     if request.method == "POST":
@@ -125,6 +131,7 @@ def delete_task(request):
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
 
 
+@login_required
 @csrf_exempt
 def task_detail_or_update(request, task_id):
     if request.method == "POST":


### PR DESCRIPTION
## Summary
- add `login_required` decorator in `core.views.helpers`
- protect the home page and all task, project and meeting views
- clean up view imports

## Testing
- `python manage.py test`