### PR TITLE
Add delete button for tasks in detail views

### DIFF
--- a/otto-ui/core/templates/core/meeting_detailview.html
+++ b/otto-ui/core/templates/core/meeting_detailview.html
@@ -66,6 +66,7 @@
           <th>Status</th>
           <th>Prio</th>
           <th>Verantwortlich</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -75,9 +76,16 @@
           <td>{{ task.status }}</td>
           <td>{{ task.prio }}</td>
           <td>{{ task.zuständig }}</td>
+          <td>
+            <form hx-post="/task/delete/" hx-confirm="Wirklich löschen?" hx-target="closest tr" hx-swap="outerHTML">
+              <input type="hidden" name="task_id" value="{{ task.id }}">
+              <button type="submit" class="btn btn-sm btn-outline-danger">🗑️</button>
+            </form>
+          </td>
         </tr>
         {% endfor %}
         <tr>
+          <td>          </td>
           <td>          </td>
           <td>          </td>
           <td>          </td>

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -99,6 +99,7 @@
           <th>Status</th>
           <th>Termin</th>
           <th>Zuständig</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -116,6 +117,12 @@
             <input type="date" class="form-control form-control-sm auto-save" data-task-id="{{ task.id }}" data-field="termin" value="{{ task.termin|slice:":10" }}">
           </td>
           <td>{{ task.zuständig }}</td>
+          <td>
+            <form hx-post="/task/delete/" hx-confirm="Wirklich löschen?" hx-target="closest tr" hx-swap="outerHTML">
+              <input type="hidden" name="task_id" value="{{ task.id }}">
+              <button type="submit" class="btn btn-sm btn-outline-danger">🗑️</button>
+            </form>
+          </td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- add action column to meeting detail page
- add action column to project detail page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python otto-ui/manage.py test`