### PR TITLE
Enable creating tasks directly from list views

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('task/update_status/', views.update_task_status, name='update_task_status'),
     path('task/update_person/', views.update_task_person, name='update_task_person'),
     path("task/delete/", views.delete_task, name="delete_task"),
+    path("task/new/", views.task_create, name="task_create"),
     path("task/<str:task_id>/", views.task_detail_or_update, name="task_detail"),
     path('meeting/', views.meeting_listview, name='meeting_liste'),
     path('meeting/<str:meeting_id>/', views.meeting_detailview, name='meeting_detail'),

--- a/otto-ui/core/templates/components/task_modal.html
+++ b/otto-ui/core/templates/components/task_modal.html
@@ -24,5 +24,22 @@
           });
       });
     });
+    document.querySelectorAll('.task-new').forEach(btn => {
+      btn.addEventListener('click', e => {
+        e.preventDefault();
+        const params = [];
+        if (btn.dataset.projectId) params.push('project_id=' + btn.dataset.projectId);
+        if (btn.dataset.meetingId) params.push('meeting_id=' + btn.dataset.meetingId);
+        const query = params.length ? '?' + params.join('&') : '';
+
+        fetch(`/task/new/${query}`)
+          .then(res => res.text())
+          .then(html => {
+            document.getElementById('taskModalContent').innerHTML = html;
+            const modal = new bootstrap.Modal(document.getElementById('taskModal'));
+            modal.show();
+          });
+      });
+    });
   });
 </script>

--- a/otto-ui/core/templates/core/meeting_listview.html
+++ b/otto-ui/core/templates/core/meeting_listview.html
@@ -17,7 +17,8 @@
             <tr>
                 <th>Bezeichnung</th>
                 <th>Datum</th>
-                <th>Mandant</th>               
+                <th>Mandant</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -25,7 +26,10 @@
             <tr>
                 <td><a href="/meeting/{{ metting.id }}">{{ metting.name }}</a></td>
                 <td>{{ metting.datum|iso_to_date }}</td>
-                <td>{{ metting.mandant }}</td>               
+                <td>{{ metting.mandant }}</td>
+                <td class="text-end">
+                    <button class="btn btn-sm btn-outline-primary task-new" data-meeting-id="{{ metting.id }}">+</button>
+                </td>
             </tr>
             {% empty %}
             <tr>

--- a/otto-ui/core/templates/core/project_listview.html
+++ b/otto-ui/core/templates/core/project_listview.html
@@ -21,6 +21,7 @@
         <th>Status</th>
         <th>Prio</th>
         <th>Bearbeiter</th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -49,6 +50,9 @@
               <option value="{{ person.id }}" {% if person.id in projekt.bearbeiter %}selected{% endif %}>{{ person.name }}</option>
             {% endfor %}
           </select>
+        </td>
+        <td class="text-end">
+          <button class="btn btn-sm btn-outline-primary task-new" data-project-id="{{ projekt.id }}">+</button>
         </td>
       </tr>
       {% endfor %}

--- a/otto-ui/core/templates/core/task_detailview.html
+++ b/otto-ui/core/templates/core/task_detailview.html
@@ -6,7 +6,7 @@
 
 </div>
 <div class="card-body">
-<form id="taskForm" data-task-id="{{ task.id }}">
+<form id="taskForm" data-task-id="{{ task.id }}" data-target-url="{% if task.id %}/task/{{ task.id }}/{% else %}/task/new/{% endif %}">
         {% csrf_token %}
         <input type="hidden" name="task_id" value="{{ task.id }}">
 
@@ -96,8 +96,8 @@ document.addEventListener('submit', function(e) {
       }
     });
 
-    const taskId = form.dataset.taskId;
-    fetch(`/task/${taskId}/`, {
+    const url = form.dataset.targetUrl;
+    fetch(url, {
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFToken': getCookie('csrftoken'),

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -1,5 +1,5 @@
 from .auth import login_view, logout_view
-from .tasks import task_listview, update_task_status, update_task_person, update_task_details, task_detail_or_update, delete_task
+from .tasks import task_listview, update_task_status, update_task_person, update_task_details, task_detail_or_update, delete_task, task_create
 from .projects import project_listview, project_detailview
 from .meetings import meeting_listview, meeting_detailview
 from django.shortcuts import render

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
 from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
-from core.const import prio_liste
+from core.const import prio_liste, status_liste
 import os
 from dotenv import load_dotenv
 
@@ -45,6 +45,47 @@ def task_listview(request):
         "tasks": offene_tasks,
         "status_liste": status_liste,
         "personen": personen
+    })
+
+
+@login_required
+@csrf_exempt
+def task_create(request):
+    if request.method == "POST":
+        try:
+            payload = json.loads(request.body)
+            res = requests.post(
+                f"{OTTO_API_URL}/tasks",
+                headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+                data=json.dumps(payload),
+            )
+            if res.status_code in (200, 201):
+                data = res.json()
+                return JsonResponse({"success": True, "id": data.get("id")})
+            return JsonResponse({"error": "Fehler beim Speichern"}, status=500)
+        except Exception as e:
+            return JsonResponse({"error": str(e)}, status=400)
+
+    task = {}
+    if request.GET.get("project_id"):
+        task["project_id"] = request.GET["project_id"]
+    if request.GET.get("meeting_id"):
+        task["meeting_id"] = request.GET["meeting_id"]
+
+    personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
+    personen = personen_res.json() if personen_res.status_code == 200 else []
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
+    meetings = meetings_res.json() if meetings_res.status_code == 200 else []
+
+    return render(request, "core/task_detailview.html", {
+        "task": task,
+        "personen": personen,
+        "projekte": projekte,
+        "meetings": meetings,
+        "prio_liste": prio_liste,
+        "status_liste": status_liste,
     })
 
 
@@ -156,7 +197,15 @@ def task_detail_or_update(request, task_id):
     task = task_res.json()
     personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
     personen = personen_res.json() if personen_res.status_code == 200 else []
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
+    meetings = meetings_res.json() if meetings_res.status_code == 200 else []
     return render(request, "core/task_detailview.html", {
         "task": task,
         "personen": personen,
+        "projekte": projekte,
+        "meetings": meetings,
+        "prio_liste": prio_liste,
+        "status_liste": status_liste,
     })


### PR DESCRIPTION
## Summary
- add `task_create` view and wire it up in URLs
- enrich task detail view with endpoints for create and update
- allow opening a modal to create a task from project/meeting lists
- extend task modal JavaScript with `.task-new` handler
- update templates to show add-task buttons

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError)*