### PR TITLE
Send bcrypt hash in login

### DIFF
--- a/otto-ui/core/views/auth.py
+++ b/otto-ui/core/views/auth.py
@@ -1,5 +1,6 @@
 import requests
 import os
+import bcrypt
 from django.shortcuts import render, redirect
 from dotenv import load_dotenv
 
@@ -7,16 +8,22 @@ load_dotenv()
 
 OTTO_API_KEY = os.getenv("OTTO_API_KEY")
 OTTO_API_URL = os.getenv("OTTO_API_URL")
+BCRYPT_SALT = os.getenv("BCRYPT_SALT")
+if BCRYPT_SALT:
+    BCRYPT_SALT = BCRYPT_SALT.encode()
+else:
+    BCRYPT_SALT = bcrypt.gensalt()
 
 def login_view(request):
     message = ""
     if request.method == "POST":
         username = request.POST.get("username")
         password = request.POST.get("password")
+        hashed_password = bcrypt.hashpw(password.encode(), BCRYPT_SALT).decode()
 
         res = requests.post(
             f"{OTTO_API_URL}/login",
-            json={"username": username, "password": password},
+            json={"username": username, "password": hashed_password},
             headers={"x-api-key": OTTO_API_KEY},
         )
         if res.status_code == 200:


### PR DESCRIPTION
## Summary
- hash password before calling the API in the Django login view
- store user passwords as sent by the client and match hashed values on login

## Testing
- `python -m py_compile otto-ui/core/views/auth.py api/controller/user_controller.py`
- `pytest -q` *(fails: command not found)*