### PR TITLE
Add dashboard to home page

### DIFF
--- a/otto-ui/core/templates/core/home.html
+++ b/otto-ui/core/templates/core/home.html
@@ -1,11 +1,111 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="container">
-    <h2>Willkommen bei Otto-ui v0.1!</h2>
-   <div class="alert alert-info">
-    Otto-ui v0.1 ist ein neuartiger, kognitiv unterstützter Planungsassistent. Im Kern steht das Konzept **COS – Cognitive Orchestrated Scheduling**:  
-Ein flexibles, KI-gestütztes System zur Erkennung, Strukturierung und Weiterverarbeitung von Aufgaben, Meetings, Entscheidungen und Verantwortlichkeiten – automatisch, nachvollziehbar, assistierend. Otto wird primäre über den ChatGPT Chat genutzt. Die UI dient lediglich dazu dem System zu assistieren. 
-   </div>
+<div class="container-fluid">
+  <h2 class="mb-4">Dashboard</h2>
+
+  <form method="get" class="mb-4">
+    <div class="input-group">
+      <input type="text" name="q" class="form-control" placeholder="Suche nach Aufgaben, Meetings oder Projekten" value="{{ search_query }}">
+      <button class="btn btn-outline-secondary" type="submit">Suchen</button>
+    </div>
+  </form>
+
+  <div class="row">
+    <div class="col-lg-6 mb-4">
+      <h5>Aufgaben nach Status</h5>
+      <canvas id="taskChart" height="200"></canvas>
+    </div>
+    <div class="col-lg-6 mb-4">
+      <h5>Anstehende Aufgaben (nächste 7 Tage)</h5>
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th>Betreff</th>
+            <th>Projekt</th>
+            <th>Termin</th>
+            <th>Prio</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for t in upcoming_tasks %}
+          <tr>
+            <td>{{ t.betreff }}</td>
+            <td>{{ t.project_id }}</td>
+            <td>{{ t._termin.strftime('%d.%m.%Y') }}</td>
+            <td>{{ t.prio }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="4">Keine offenen Aufgaben</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-6 mb-4">
+      <h5>Letzte Meetings</h5>
+      <ul class="list-group">
+        {% for m in past_meetings %}
+        <li class="list-group-item">
+          <a href="/meeting/{{ m.id }}/">{{ m.name }}</a> – {{ m.datum }}
+        </li>
+        {% empty %}
+        <li class="list-group-item">Keine Meetings</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="col-lg-6 mb-4">
+      <h5>Kommende Meetings</h5>
+      <ul class="list-group">
+        {% for m in future_meetings %}
+        <li class="list-group-item">
+          <a href="/meeting/{{ m.id }}/">{{ m.name }}</a> – {{ m.datum }}
+        </li>
+        {% empty %}
+        <li class="list-group-item">Keine Meetings</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+
+  {% if project_status %}
+  <div class="mt-4">
+    <h5>Projekte</h5>
+    <div class="row row-cols-1 row-cols-md-3 g-3">
+      {% for p in project_status %}
+      <div class="col">
+        <div class="card h-100">
+          <div class="card-body">
+            <h6 class="card-title">{{ p.name }}</h6>
+            <p class="card-text mb-0">Status: {{ p.status }}</p>
+            <small>Offen: {{ p.offen }} | Erledigt: {{ p.erledigt }}</small>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
 </div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script>
+  const ctx = document.getElementById('taskChart');
+  if(ctx){
+    new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: {{ task_status_labels|safe }},
+        datasets: [{
+          data: {{ task_status_counts|safe }},
+          backgroundColor: ['#0d6efd','#198754','#ffc107','#dc3545','#6c757d']
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false}
+    });
+  }
+</script>
 {% endblock %}
+

--- a/otto-ui/core/views.py
+++ b/otto-ui/core/views.py
@@ -3,9 +3,114 @@ from .views.tasks import task_listview, update_task_status, update_task_person, 
 from .views.projects import project_listview, project_detailview
 from .views.meetings import meeting_listview, meeting_detailview
 from django.shortcuts import render
+from .views.helpers import login_required
+import os
+import requests
+import json
+from datetime import datetime, timedelta
+from collections import Counter
+from dotenv import load_dotenv
 
+load_dotenv()
+
+OTTO_API_KEY = os.getenv("OTTO_API_KEY")
+OTTO_API_URL = os.getenv("OTTO_API_URL")
+
+@login_required
 def home(request):
-    return render(request, "core/home.html")
+    q = request.GET.get("q", "").lower()
+
+    # Daten abrufen
+    tasks = []
+    meetings = []
+    projekte = []
+    try:
+        t_res = requests.get(f"{OTTO_API_URL}/tasks", headers={"x-api-key": OTTO_API_KEY})
+        if t_res.status_code == 200:
+            tasks = t_res.json()
+        m_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
+        if m_res.status_code == 200:
+            meetings = m_res.json()
+        p_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+        if p_res.status_code == 200:
+            projekte = p_res.json()
+    except Exception:
+        pass
+
+    if q:
+        tasks = [t for t in tasks if q in t.get("betreff", "").lower()]
+        meetings = [m for m in meetings if q in m.get("name", "").lower()]
+        projekte = [p for p in projekte if q in p.get("name", "").lower()]
+
+    # Aufgaben nach Status
+    status_counter = Counter(t.get("status", "Unbekannt") or "Unbekannt" for t in tasks)
+    status_labels = list(status_counter.keys())
+    status_values = list(status_counter.values())
+
+    # Anstehende Aufgaben
+    now = datetime.now()
+    upcoming_tasks = []
+    for t in tasks:
+        termin_dt = parse_termin(t)
+        if termin_dt != datetime.max and now <= termin_dt <= now + timedelta(days=7):
+            t["_termin"] = termin_dt
+            upcoming_tasks.append(t)
+    upcoming_tasks.sort(key=lambda x: x["_termin"])
+
+    # Meetings
+    past_meetings = []
+    future_meetings = []
+    for m in meetings:
+        try:
+            m_dt = datetime.fromisoformat(m.get("datum")) if m.get("datum") else None
+        except Exception:
+            m_dt = None
+        if not m_dt:
+            continue
+        if m_dt < now:
+            past_meetings.append((m_dt, m))
+        elif m_dt <= now + timedelta(days=7):
+            future_meetings.append((m_dt, m))
+    past_meetings.sort(key=lambda x: x[0], reverse=True)
+    future_meetings.sort(key=lambda x: x[0])
+    past_meetings = [m for _, m in past_meetings[:3]]
+    future_meetings = [m for _, m in future_meetings[:3]]
+
+    # Projektstatus
+    tasks_by_project = {}
+    for t in tasks:
+        pid = t.get("project_id")
+        if pid:
+            tasks_by_project.setdefault(pid, []).append(t)
+
+    project_status = []
+    for p in projekte:
+        tid = p.get("id")
+        p_tasks = tasks_by_project.get(tid, [])
+        offen = len([t for t in p_tasks if t.get("status") != "✅ abgeschlossen"])
+        erledigt = len([t for t in p_tasks if t.get("status") == "✅ abgeschlossen"])
+        project_status.append({
+            "id": tid,
+            "name": p.get("name"),
+            "status": p.get("status"),
+            "offen": offen,
+            "erledigt": erledigt,
+        })
+
+    context = {
+        "task_status_labels": json.dumps(status_labels),
+        "task_status_counts": json.dumps(status_values),
+        "upcoming_tasks": upcoming_tasks,
+        "past_meetings": past_meetings,
+        "future_meetings": future_meetings,
+        "project_status": project_status,
+        "search_query": q,
+        "tasks": tasks,
+        "meetings": meetings,
+        "projekte": projekte,
+    }
+
+    return render(request, "core/home.html", context)
 
 def parse_termin(t):
     from datetime import datetime


### PR DESCRIPTION
## Summary
- create dashboard on home page showing quick search, charts and upcoming tasks
- compute metrics for tasks, meetings and projects in the home view

## Testing
- `python3 -m py_compile otto-ui/core/views.py`