### PR TITLE
Add task type field across UI

### DIFF
--- a/api/model/task.py
+++ b/api/model/task.py
@@ -10,6 +10,7 @@ class Task(BaseModel):
     aufwand: int
     notizen: Optional[str] = ""
     prio: Optional[str]  # z.B. "hoch", "mittel", "niedrig"
+    typ: Optional[str] = None
     termin: Optional[date] = None
     status: str  # z.B. "offen", "in Arbeit", "erledigt"
     project_id: Optional[str] = None

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('task/update/', views.update_task_details, name='update_task_details'),
     path('task/update_status/', views.update_task_status, name='update_task_status'),
     path('task/update_person/', views.update_task_person, name='update_task_person'),
+    path('task/update_typ/', views.update_task_typ, name='update_task_typ'),
     path("task/delete/", views.delete_task, name="delete_task"),
     path("task/new/", views.task_create, name="task_create"),
     path("task/<str:task_id>/", views.task_detail_or_update, name="task_detail"),

--- a/otto-ui/core/const.py
+++ b/otto-ui/core/const.py
@@ -3,3 +3,4 @@ import json
 status_liste = ["✨ neu", "🚧 in Arbeit", "📦 laufend", "⏸️ wartet", "✅ abgeschlossen"]
 prio_liste = ["🔴 kritisch", "🟠 hoch", "🟢 normal", "🔵 niedrig"]
 mandanten_liste = ["HAM", "DHGS", "SCU", "HSSH", "Triagon", "IFI", "ISARtec", "IUNWorld", "Alle"]
+typ_liste = ["Aufgabe", "Bug", "Feature", "Requirement", "Change"]

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -104,6 +104,7 @@
         <tr>
           <th>Betreff</th>
           <th>Status</th>
+          <th>Typ</th>
           <th>Termin</th>
           <th>Zuständig</th>
           <th></th>
@@ -117,6 +118,13 @@
             <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="status">
               {% for s in status_liste %}
                 <option value="{{ s }}" {% if s == task.status %}selected{% endif %}>{{ s }}</option>
+              {% endfor %}
+            </select>
+          </td>
+          <td>
+            <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="typ">
+              {% for t in typ_liste %}
+                <option value="{{ t }}" {% if t == task.typ %}selected{% endif %}>{{ t }}</option>
               {% endfor %}
             </select>
           </td>

--- a/otto-ui/core/templates/core/task_detailview.html
+++ b/otto-ui/core/templates/core/task_detailview.html
@@ -75,6 +75,15 @@
         </div>
 
         <div class="mb-3">
+            <label class="form-label">Typ</label>
+            <select class="form-select" name="typ">
+                {% for t in typ_liste %}
+                    <option value="{{ t }}" {% if task.typ == t %}selected{% endif %}>{{ t }}</option>
+                {% endfor %}
+            </select>
+        </div>
+
+        <div class="mb-3">
             <label class="form-label">Aufwand (Stunden)</label>
             <input class="form-control" type="number" name="aufwand" value="{{ task.aufwand }}">
         </div>

--- a/otto-ui/core/templates/core/task_listview.html
+++ b/otto-ui/core/templates/core/task_listview.html
@@ -38,6 +38,7 @@
         <thead>
             <tr>
                 <th>Betreff</th>
+                <th>Typ</th>
                 <th>Status</th>
                 <th>Zuständig</th>
                 <th>Termin</th>
@@ -48,6 +49,16 @@
             {% for task in tasks %}
             <tr>
                 <td><a href="#" class="task-open" data-task-id="{{ task.id }}">{{ task.betreff }}</a></td>
+                <td>
+                    <form hx-post="/task/update_typ/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
+                        <input type="hidden" name="task_id" value="{{ task.id }}">
+                        <select class="form-select form-select-sm" name="typ">
+                            {% for t in typ_liste %}
+                                <option value="{{ t }}" {% if task.typ == t %}selected{% endif %}>{{ t }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                </td>
                 <td>
                     <form hx-post="/task/update_status/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
                         <input type="hidden" name="task_id" value="{{ task.id }}">
@@ -77,7 +88,7 @@
                 </td>
             </tr>
             {% empty %}
-            <tr><td colspan="5">Keine offenen Aufgaben gefunden.</td></tr>
+            <tr><td colspan="6">Keine offenen Aufgaben gefunden.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -1,5 +1,5 @@
 from .auth import login_view, logout_view
-from .tasks import task_listview, update_task_status, update_task_person, update_task_details, task_detail_or_update, delete_task, task_create
+from .tasks import task_listview, update_task_status, update_task_person, update_task_typ, update_task_details, task_detail_or_update, delete_task, task_create
 from .projects import project_listview, project_detailview, delete_project
 from .meetings import meeting_listview, meeting_detailview, meeting_create
 from django.shortcuts import render

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
 from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
-from core.const import status_liste, prio_liste
+from core.const import status_liste, prio_liste, typ_liste
 import os
 from dotenv import load_dotenv
 
@@ -71,7 +71,8 @@ def project_detailview(request, project_id):
         "tasks": tasks,
         "dateien": dateien,
         "status_liste": status_liste,
-        "prio_liste": prio_liste
+        "prio_liste": prio_liste,
+        "typ_liste": typ_liste
     })
 
 

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -5,7 +5,7 @@ from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
 from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
-from core.const import prio_liste, status_liste
+from core.const import prio_liste, status_liste, typ_liste
 import os
 from dotenv import load_dotenv
 
@@ -59,6 +59,7 @@ def task_listview(request):
     return render(request, "core/task_listview.html", {
         "tasks": paginated_tasks,
         "status_liste": status_liste,
+        "typ_liste": typ_liste,
         "personen": personen,
         "page": page,
         "total_pages": total_pages,
@@ -104,6 +105,7 @@ def task_create(request):
         "meetings": meetings,
         "prio_liste": prio_liste,
         "status_liste": status_liste,
+        "typ_liste": typ_liste,
     })
 
 
@@ -149,6 +151,26 @@ def update_task_person(request):
 
 @login_required
 @csrf_exempt
+def update_task_typ(request):
+    if request.method == "POST":
+        task_id = request.POST.get("task_id")
+        new_typ = request.POST.get("typ")
+        get_res = requests.get(f"{OTTO_API_URL}/tasks/{task_id}", headers={"x-api-key": OTTO_API_KEY})
+        if get_res.status_code != 200:
+            return JsonResponse({"error": "Task nicht gefunden."}, status=404)
+        task = get_res.json()
+        task["typ"] = new_typ
+        update_res = requests.put(
+            f"{OTTO_API_URL}/tasks/{task_id}",
+            headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+            data=json.dumps(task)
+        )
+        return HttpResponse("OK") if update_res.status_code == 200 else JsonResponse({"error": "Fehler beim Speichern."}, status=500)
+    return JsonResponse({"error": "Ungültige Methode."}, status=405)
+
+
+@login_required
+@csrf_exempt
 def update_task_details(request):
     if request.method == "POST":
         task_id = request.POST.get("task_id")
@@ -160,6 +182,7 @@ def update_task_details(request):
         task["beschreibung"] = request.POST.get("beschreibung")
         task["status"] = request.POST.get("status")
         task["prio"] = request.POST.get("prio")
+        task["typ"] = request.POST.get("typ")
         task["person_id"] = request.POST.get("person_id")
         task["project_id"] = request.POST.get("project_id") or None
         task["meeting_id"] = request.POST.get("meeting_id") or None
@@ -226,4 +249,5 @@ def task_detail_or_update(request, task_id):
         "meetings": meetings,
         "prio_liste": prio_liste,
         "status_liste": status_liste,
+        "typ_liste": typ_liste,
     })


### PR DESCRIPTION
## Summary
- add `typ_liste` constant
- extend Task model with `typ`
- expose new field on all task views and templates
- make type editable in task list and project detail views
- wire up `update_task_typ` route and handler

## Testing
- `python3 -m py_compile api/model/task.py otto-ui/core/views/tasks.py otto-ui/core/views/projects.py otto-ui/core/views/__init__.py`
- `pytest -q`