### PR TITLE
Add project priority on dashboard

### DIFF
--- a/api/model/projekt.py
+++ b/api/model/projekt.py
@@ -11,7 +11,10 @@ class Projekt(BaseModel):
     short: Optional[str]
     klassifikation: str
     status: str
-    prio: str  # z.B. "hoch", "mittel", "niedrig"
+    prio: Optional[str] = Field(
+        "🟢 normal",
+        description="Projektpriorität (z.B. 'hoch', 'mittel', 'niedrig')",
+    )
     bearbeiter: Optional[str] = Field(None, description="Verknüpfung zu Personen ID")
     devops_project_id: Optional[str] = Field(
         default=None,

--- a/otto-ui/core/templates/core/home.html
+++ b/otto-ui/core/templates/core/home.html
@@ -29,6 +29,7 @@
           <div class="card-body">
             <h6 class="card-title">{{ p.name }}</h6>
             <p class="card-text mb-0">Status: {{ p.status }}</p>
+            <p class="card-text mb-0">Prio: {{ p.prio }}</p>
             <small>Offen: {{ p.offen }} | Erledigt: {{ p.erledigt }}</small>
           </div>
         </div>

--- a/otto-ui/core/views.py
+++ b/otto-ui/core/views.py
@@ -102,6 +102,7 @@ def home(request):
             "id": tid,
             "name": p.get("name"),
             "status": p.get("status"),
+            "prio": p.get("prio"),
             "offen": offen,
             "erledigt": erledigt
         })

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -110,6 +110,7 @@ def home(request):
                 "id": tid,
                 "name": p.get("name"),
                 "status": p.get("status"),
+                "prio": p.get("prio"),
                 "offen": offen,
                 "erledigt": erledigt,
             }


### PR DESCRIPTION
## Summary
- include project priority in the dashboard context
- define default priority on the API's Projekt model

## Testing
- `python -m py_compile otto-ui/core/views.py otto-ui/core/views/__init__.py api/model/projekt.py`