### PR TITLE
Dashboard links and task detail page

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
     path("task/delete/", views.delete_task, name="delete_task"),
     path('task/update/', views.update_task_details, name='update_task_details'),
     path("task/new/", views.task_create, name="task_create"),
+    path('task/view/<str:task_id>/', views.task_pageview, name='task_pageview'),
     path("task/<str:task_id>/", views.task_detail_or_update, name="task_detail"),
     path('meeting/', views.meeting_listview, name='meeting_liste'),
     path('meeting/new/', views.meeting_create, name='meeting_create'),

--- a/otto-ui/core/const.py
+++ b/otto-ui/core/const.py
@@ -3,5 +3,11 @@ import json
 status_liste = ["✨ neu", "🚧 in Arbeit", "📦 laufend", "⏸️ wartet", "✅ abgeschlossen"]
 prio_liste = ["🔴 kritisch", "🟠 hoch", "🟢 normal", "🔵 niedrig"]
 mandanten_liste = ["HAM", "DHGS", "SCU", "HSSH", "Triagon", "IFI", "ISARtec", "IUNWorld", "Alle"]
-typ_liste = ["Aufgabe", "Bug", "Feature", "Requirement", "Change"]
+typ_liste = [
+    "📝 Aufgabe",
+    "🐞 Bug",
+    "✨ Feature",
+    "📋 Requirement",
+    "🔄 Change",
+]
 projekt_typ = ["Meeting", "Projekt"]

--- a/otto-ui/core/templates/core/home.html
+++ b/otto-ui/core/templates/core/home.html
@@ -27,7 +27,7 @@
       <div class="col">
         <div class="card h-100">
           <div class="card-body">
-            <h6 class="card-title">{{ p.name }}</h6>
+            <h6 class="card-title"><a href="/project/{{ p.id }}/">{{ p.name }}</a></h6>
             <p class="card-text mb-0">Typ: {{ p.typ }}</p>
             <p class="card-text mb-0">Status: {{ p.status }}</p>
             <p class="card-text mb-0">Prio: {{ p.prio }}</p>
@@ -53,7 +53,7 @@
         <tbody>
           {% for t in upcoming_tasks %}
           <tr>
-            <td>{{ t.betreff }}</td>           
+            <td><a href="/task/view/{{ t.id }}/">{{ t.betreff }}</a></td>
             <td>{{ t.termin_dt|date:"d.m.Y" }}</td>
             <td>{{ t.prio }}</td>
           </tr>

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -1,0 +1,125 @@
+{% extends "base.html" %}
+{% block content %}
+<script>
+  window.ottoContext = {
+    type: "Aufgaben",
+    name: "{{ task.betreff }}",
+    id: "{{ task.id }}"
+  }
+</script>
+<div class="container py-4">
+  <div class="card mb-3">
+    <div class="card-header">
+      <h3 class="mb-0">Aufgabe bearbeiten</h3>
+    </div>
+    <div class="card-body">
+      <form id="taskForm">
+        {% csrf_token %}
+        <input type="hidden" name="task_id" value="{{ task.id }}">
+        <div class="mb-3">
+          <label class="form-label">Betreff</label>
+          <input class="form-control" type="text" name="betreff" value="{{ task.betreff }}">
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Beschreibung</label>
+          <textarea class="form-control" name="beschreibung">{{ task.beschreibung }}</textarea>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Projekt</label>
+          <select class="form-select" name="project_id">
+            <option value="">-- Kein Projekt --</option>
+            {% for projekt in projekte %}
+            <option value="{{ projekt.id }}" {% if task.project_id == projekt.id %}selected{% endif %}>{{ projekt.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Meeting</label>
+          <select class="form-select" name="meeting_id">
+            <option value="">-- Kein Meeting --</option>
+            {% for meeting in meetings %}
+            <option value="{{ meeting.id }}" {% if task.meeting_id == meeting.id %}selected{% endif %}>{{ meeting.name }}{% if meeting.datum_formatiert %} ({{ meeting.datum_formatiert }}){% endif %}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Zuständig</label>
+          <select class="form-select" name="person_id">
+            {% for person in personen %}
+            <option value="{{ person.id }}" {% if task.person_id == person.id %}selected{% endif %}>{{ person.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Status</label>
+          <select class="form-select" name="status">
+            {% for status in status_liste %}
+            <option value="{{ status }}" {% if task.status == status %}selected{% endif %}>{{ status }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Priorität</label>
+          <select class="form-select" name="prio">
+            {% for p in prio_liste %}
+            <option value="{{ p }}" {% if task.prio == p %}selected{% endif %}>{{ p }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Typ</label>
+          <select class="form-select" name="typ">
+            {% for t in typ_liste %}
+            <option value="{{ t }}" {% if task.typ == t %}selected{% endif %}>{{ t }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Aufwand (Stunden)</label>
+          <input class="form-control" type="number" name="aufwand" value="{{ task.aufwand }}">
+        </div>
+        <button type="submit" class="btn btn-primary">Speichern</button>
+      </form>
+    </div>
+  </div>
+  <div id="saveSuccess" class="alert alert-success d-none">Gespeichert!</div>
+</div>
+<script>
+function getCookie(name){
+  let cookieValue = null;
+  if(document.cookie && document.cookie !== ''){
+    const cookies = document.cookie.split(';');
+    for(let i=0;i<cookies.length;i++){
+      const cookie = cookies[i].trim();
+      if(cookie.substring(0,name.length+1) === (name+'=')){
+        cookieValue = decodeURIComponent(cookie.substring(name.length+1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+const form = document.getElementById('taskForm');
+const successBox = document.getElementById('saveSuccess');
+form.addEventListener('submit', function(e){
+  e.preventDefault();
+  const data = {};
+  new FormData(form).forEach((v,k)=>{data[k]=v});
+  fetch('', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCookie('csrftoken'),
+    },
+    body: JSON.stringify(data)
+  }).then(r => {
+    if(r.ok){
+      successBox.classList.remove('d-none');
+      setTimeout(()=>successBox.classList.add('d-none'),2000);
+    }else{
+      alert('Fehler beim Speichern');
+    }
+  });
+});
+</script>
+{% endblock %}

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -275,3 +275,42 @@ def task_detail_or_update(request, task_id):
         "status_liste": status_liste,
         "typ_liste": typ_liste,
     })
+
+@login_required
+@csrf_exempt
+def task_pageview(request, task_id):
+    if request.method == "POST":
+        try:
+            payload = json.loads(request.body)
+            res = requests.get(f"{OTTO_API_URL}/tasks/{task_id}", headers={"x-api-key": OTTO_API_KEY})
+            if res.status_code != 200:
+                return JsonResponse({"error": "Task nicht gefunden"}, status=404)
+            task = res.json()
+            for key, value in payload.items():
+                task[key] = value
+            update = requests.put(
+                f"{OTTO_API_URL}/tasks/{task_id}",
+                headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+                data=json.dumps(task)
+            )
+            return JsonResponse({"success": True}) if update.status_code == 200 else JsonResponse({"error": "Fehler beim Speichern"}, status=500)
+        except Exception as e:
+            return JsonResponse({"error": str(e)}, status=400)
+
+    task_res = requests.get(f"{OTTO_API_URL}/tasks/{task_id}", headers={"x-api-key": OTTO_API_KEY})
+    task = task_res.json()
+    personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
+    personen = personen_res.json() if personen_res.status_code == 200 else []
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
+    meetings = meetings_res.json() if meetings_res.status_code == 200 else []
+    return render(request, "core/task_detailpage.html", {
+        "task": task,
+        "personen": personen,
+        "projekte": projekte,
+        "meetings": meetings,
+        "prio_liste": prio_liste,
+        "status_liste": status_liste,
+        "typ_liste": typ_liste,
+    })


### PR DESCRIPTION
## Summary
- create full page to edit tasks outside of modal
- link dashboard project cards and upcoming tasks to their details
- add emoji icons to task type list

## Testing
- `python -m py_compile otto-ui/core/views/tasks.py otto-ui/config/urls.py otto-ui/core/const.py`
- `pytest -q`