### PR TITLE
Fix sticky footer covering content

### DIFF
--- a/otto-ui/core/templates/base.html
+++ b/otto-ui/core/templates/base.html
@@ -15,6 +15,7 @@
 
         body, html {
             height: 100%;
+            min-height: 100%;
         }
         .sidebar-left {
             width: 250px;
@@ -33,8 +34,7 @@
         .footer {
             background-color: #e0e0e0;
             padding: 0.5rem;
-            position: sticky;
-            bottom: 0;
+            margin-top: auto;
             width: 100%;
         }
         .header {
@@ -50,7 +50,7 @@
         }
     </style>
 </head>
-<body class="d-flex flex-column"  style="height: 100%;">
+<body class="d-flex flex-column" style="min-height: 100vh;">
 <nav class="navbar navbar-expand navbar-dark" style="background-color: #004d40 !important;height: 60px;">
   <div class="container-fluid">
     <a class="navbar-brand text-white mb-0 h2" href="/">Otto UI v0.1</a>
@@ -84,7 +84,7 @@
 </nav>
  
 
-    <div class="d-flex flex-grow-1" style="height: 100%;">     
+    <div class="d-flex flex-grow-1">
 
         <main class="main-content">
             {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- prevent footer from covering content in `base.html`

## Testing
- `pytest -q`
- `python -m py_compile `git ls-files '*.py'``