### PR TITLE
Fix task detail fields and link to new view

### DIFF
--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -114,7 +114,7 @@
       <tbody>
         {% for task in tasks %}
         <tr id="task-{{ task.id }}">
-          <td><a href="#" class="task-open" data-task-id="{{ task.id }}">{{ task.betreff }}</a></td>
+          <td><a href="/task/view/{{ task.id }}/">{{ task.betreff }}</a></td>
           <td>
             <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="status">
               {% for s in status_liste %}

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -51,6 +51,10 @@
           </select>
         </div>
         <div class="mb-3">
+          <label class="form-label">Termin</label>
+          <input class="form-control" type="date" name="termin" value="{{ task.termin|slice:":10" }}">
+        </div>
+        <div class="mb-3">
           <label class="form-label">Status</label>
           <select class="form-select" name="status">
             {% for status in status_liste %}

--- a/otto-ui/core/templates/core/task_listview.html
+++ b/otto-ui/core/templates/core/task_listview.html
@@ -48,7 +48,7 @@
         <tbody>
             {% for task in tasks %}
             <tr>
-                <td><a href="#" class="task-open" data-task-id="{{ task.id }}">{{ task.betreff }}</a></td>
+                <td><a href="/task/view/{{ task.id }}/">{{ task.betreff }}</a></td>
                 <td>
                     <form hx-post="/task/update_typ/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
                         <input type="hidden" name="task_id" value="{{ task.id }}">


### PR DESCRIPTION
## Summary
- add a missing `Termin` field to the task detail page
- link tasks to `/task/view/<id>/` from project and task list views

## Testing
- `pytest -q`