### PR TITLE
Make header/footer sticky

### DIFF
--- a/otto-ui/core/templates/base.html
+++ b/otto-ui/core/templates/base.html
@@ -36,11 +36,22 @@
             padding: 0.5rem;
             margin-top: auto;
             width: 100%;
+            position: sticky;
+            bottom: 0;
         }
         .header {
             background-color: #004d40;
             color: white;
             padding: 1rem;
+        }
+        .navbar {
+            position: sticky;
+            top: 0;
+            z-index: 1020;
+        }
+        .content-wrapper {
+            overflow-y: auto;
+            flex-grow: 1;
         }
         #snackbar {
             position: fixed;
@@ -50,7 +61,7 @@
         }
     </style>
 </head>
-<body class="d-flex flex-column" style="min-height: 100vh;">
+<body class="d-flex flex-column" style="height: 100vh; overflow: hidden;">
 <nav class="navbar navbar-expand navbar-dark" style="background-color: #004d40 !important;height: 60px;">
   <div class="container-fluid">
     <a class="navbar-brand text-white mb-0 h2" href="/">Otto UI v0.1</a>
@@ -84,7 +95,7 @@
 </nav>
  
 
-    <div class="d-flex flex-grow-1">
+    <div class="d-flex flex-grow-1 content-wrapper">
 
         <main class="main-content">
             {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- sticky header and footer
- allow content to scroll between

## Testing
- `pytest -q`