### PR TITLE
Add Short field to project views

### DIFF
--- a/otto-ui/core/templates/core/home.html
+++ b/otto-ui/core/templates/core/home.html
@@ -27,7 +27,9 @@
       <div class="col">
         <div class="card h-100">
           <div class="card-body">
-            <h6 class="card-title"><a href="/project/{{ p.id }}/">{{ p.name }}</a></h6>
+            <h6 class="card-title">
+              <a href="/project/{{ p.id }}/">{{ p.name }}{% if p.short %} ({{ p.short }}){% endif %}</a>
+            </h6>
             <p class="card-text mb-0">Typ: {{ p.typ }}</p>
             <p class="card-text mb-0">Status: {{ p.status }}</p>
             <p class="card-text mb-0">Prio: {{ p.prio }}</p>

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -27,6 +27,12 @@
                 </div>
                 <div class="col-12">
                     <div class="mb-3">
+                        <label class="form-label">Short</label>
+                        <input type="text" name="short" class="form-control" value="{{ projekt.short }}">
+                    </div>
+                </div>
+                <div class="col-12">
+                    <div class="mb-3">
                         <label class="form-label">Beschreibung</label>
                         <textarea name="beschreibung" class="form-control">{{ projekt.beschreibung }}</textarea>
                     </div>

--- a/otto-ui/core/views.py
+++ b/otto-ui/core/views.py
@@ -101,6 +101,7 @@ def home(request):
         project_status.append({
             "id": tid,
             "name": p.get("name"),
+            "short": p.get("short"),
             "status": p.get("status"),
             "prio": p.get("prio"),
             "offen": offen,

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -124,6 +124,7 @@ def home(request):
             {
                 "id": tid,
                 "name": p.get("name"),
+                "short": p.get("short"),
                 "typ": p.get("typ"),
                 "status": p.get("status"),
                 "prio": p.get("prio"),


### PR DESCRIPTION
## Summary
- include Short in dashboard project tiles
- support Short in project detail view

## Testing
- `python -m py_compile otto-ui/core/views/__init__.py`
- `python -m py_compile otto-ui/core/views.py`
- `python -m py_compile otto-ui/core/views/projects.py`