### PR TITLE
Implement email message support

### DIFF
--- a/api/controller/message_controller.py
+++ b/api/controller/message_controller.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+from bson import ObjectId
+from helper import verify_api_key, serialize_mongo
+from mongo import db
+from model.message import Message
+
+router = APIRouter()
+
+@router.post("/messages", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def create_message(message: Message):
+    result = await db.messages.insert_one(message.dict())
+    return {"status": "ok", "id": str(result.inserted_id)}
+
+@router.get("/messages", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def list_messages():
+    cursor = db.messages.find()
+    return [serialize_mongo(m) async for m in cursor]
+
+@router.get("/messages/{message_id}", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def get_message(message_id: str):
+    msg = await db.messages.find_one({"_id": ObjectId(message_id)})
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return serialize_mongo(msg)
+
+@router.delete("/messages/{message_id}", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def delete_message(message_id: str):
+    result = await db.messages.delete_one({"_id": ObjectId(message_id)})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"status": "deleted"}
+
+@router.get("/project/{project_id}/messages", dependencies=[Depends(verify_api_key)], tags=["Projekt"])
+async def get_messages_by_project(project_id: str):
+    cursor = db.messages.find({"project_id": project_id}).sort("datum", -1)
+    return [serialize_mongo(m) async for m in cursor]

--- a/api/main.py
+++ b/api/main.py
@@ -72,6 +72,12 @@ try:
 except Exception as e:
     print(f"⚠️ Fehler beim Einbinden von sharepoint_router: {e}")
 
+try:
+    from controller.message_controller import router as message_router
+    app.include_router(message_router)
+except Exception as e:
+    print(f"⚠️ Fehler beim Einbinden von message_controller: {e}")
+
 def custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema

--- a/api/model/message.py
+++ b/api/model/message.py
@@ -1,17 +1,17 @@
 # model.py – Teil des Otto KI-Systems
 # © Christian Angermeier 2025
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr
 from typing import List, Optional, Literal
-from datetime import datetime, date
+from datetime import datetime
 
 class Message(BaseModel):
-    message_id: str
+    """Repräsentiert eine E-Mail Nachricht."""
+
+    datum: datetime
     subject: str
-    body: str
-    sender: str
-    recipient: str
-    date: datetime
-    direction: str  # "in" oder "out"
-    projekt_id: Optional[str] = None
-    aufgabe_id: Optional[str] = None
+    to: List[EmailStr]
+    cc: Optional[List[EmailStr]] = None
+    message: str  # HTML Inhalt
+    direction: Literal["in", "out"]
+    project_id: Optional[str] = None

--- a/api/mongo.py
+++ b/api/mongo.py
@@ -14,6 +14,7 @@ projekte_collection = db.projekte
 personen_collection = db.personen
 meeting_collection = db.meeting
 users = db["users"]
+messages_collection = db.messages
 db.meetings.delete_many({"id": ""})
 
 def get_tagesplan_collection() -> Collection:

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('meeting/<str:meeting_id>/', views.meeting_detailview, name='meeting_detail'),
     path('person/', views.person_listview, name='person_liste'),
     path('person/<str:person_id>/', views.person_detailview, name='person_detail'),
+    path('message/<str:message_id>/', views.message_detailview, name='message_detail'),
     path('login/', login_view, name='login'),
     path('logout/', logout_view, name='logout'),
 

--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container py-4">
+  <div class="card">
+    <div class="card-header">
+      {{ message.subject }}
+    </div>
+    <div class="card-body">
+      <p><strong>Datum:</strong> {{ message.datum }}</p>
+      <p><strong>To:</strong> {{ message.to|join:', ' }}</p>
+      <p><strong>Cc:</strong> {{ message.cc|default_if_none:''|join:', ' }}</p>
+      <div class="mt-3 border p-3" style="background:white;">
+        {{ message.message|safe }}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -95,12 +95,15 @@
 
   <hr class="my-4">
 
-  <ul class="nav nav-tabs" id="tabs" role="tablist">  
+  <ul class="nav nav-tabs" id="tabs" role="tablist">
     <li class="nav-item" role="presentation">
       <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tasks" type="button" role="tab">Tasks</button>
-    </li>  
+    </li>
     <li class="nav-item" role="presentation">
       <button class="nav-link" data-bs-toggle="tab" data-bs-target="#files" type="button" role="tab">Dateien</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" data-bs-toggle="tab" data-bs-target="#messages" type="button" role="tab">Nachrichten</button>
     </li>
   </ul>
 <div class="tab-content mt-3">
@@ -192,6 +195,32 @@
         </ul>
     {% else %}
         <p>Keine Dateien vorhanden.</p>
+   {% endif %}
+    </div>
+    <div class="tab-pane fade" id="messages" role="tabpanel">
+    {% if messages %}
+      <table class="table table-sm table-striped">
+        <thead>
+          <tr>
+            <th>Datum</th>
+            <th>Betreff</th>
+            <th>To</th>
+            <th>Richtung</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for mail in messages %}
+          <tr>
+            <td>{{ mail.datum|slice:':19' }}</td>
+            <td><a href="/message/{{ mail.id }}/">{{ mail.subject }}</a></td>
+            <td>{{ mail.to|join:', ' }}</td>
+            <td>{{ mail.direction }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>Keine Nachrichten vorhanden.</p>
     {% endif %}
     </div>
   </div>

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -18,6 +18,7 @@ from .projects import (
 )
 from .meetings import meeting_listview, meeting_detailview, meeting_create
 from .persons import person_listview, person_detailview
+from .messages import message_detailview
 from django.shortcuts import render
 from .helpers import login_required
 import os

--- a/otto-ui/core/views/messages.py
+++ b/otto-ui/core/views/messages.py
@@ -1,0 +1,21 @@
+import os
+import requests
+from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
+from .helpers import login_required
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OTTO_API_KEY = os.getenv("OTTO_API_KEY")
+OTTO_API_URL = os.getenv("OTTO_API_URL")
+
+
+@login_required
+def message_detailview(request, message_id):
+    res = requests.get(
+        f"{OTTO_API_URL}/messages/{message_id}",
+        headers={"x-api-key": OTTO_API_KEY},
+    )
+    message = res.json() if res.status_code == 200 else {}
+    return render(request, "core/message_detailview.html", {"message": message})

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -65,6 +65,8 @@ def project_detailview(request, project_id):
     dateien = dateien_res.json() if dateien_res.status_code == 200 else []
     tasks_res = requests.get(f"{OTTO_API_URL}/project/{project_id}/tasks", headers={"x-api-key": OTTO_API_KEY})
     tasks = tasks_res.json() if tasks_res.status_code == 200 else []
+    messages_res = requests.get(f"{OTTO_API_URL}/project/{project_id}/messages", headers={"x-api-key": OTTO_API_KEY})
+    messages = messages_res.json() if messages_res.status_code == 200 else []
     personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
     personen = personen_res.json() if personen_res.status_code == 200 else []
 
@@ -72,6 +74,7 @@ def project_detailview(request, project_id):
         "projekt": projekt,
         "personen": personen,
         "tasks": tasks,
+        "messages": messages,
         "dateien": dateien,
         "status_liste": status_liste,
         "prio_liste": prio_liste,


### PR DESCRIPTION
## Summary
- introduce new Message model with recipients and HTML body
- connect MongoDB `messages` collection and add REST routes
- add message view endpoint in Django and template for message details
- extend project detail page with a tab listing related messages

## Testing
- `python3 -m py_compile api/main.py api/model/message.py api/mongo.py api/controller/message_controller.py otto-ui/core/views/messages.py otto-ui/core/views/projects.py otto-ui/core/views/__init__.py otto-ui/config/urls.py`
