### PR TITLE
Add TID field to tasks

### DIFF
--- a/api/model/task.py
+++ b/api/model/task.py
@@ -3,6 +3,7 @@ from typing import Optional
 from datetime import date
 
 class Task(BaseModel):
+    tid: Optional[int] = None
     betreff: str
     beschreibung: Optional[str] = ""
     tasktype: Optional[str] = Field(None, description="Typ der Aufgabe, z.B. 'Aufgabe', 'Feature', 'Bug', 'Ticket', 'Requirement', 'Sonstiges'")

--- a/otto-ui/core/templates/core/home.html
+++ b/otto-ui/core/templates/core/home.html
@@ -48,7 +48,8 @@
            <table class="table table-sm table-hover table-striped">
         <thead>
           <tr>
-            <th>Betreff</th>           
+            <th>TID</th>
+            <th>Betreff</th>
             <th>Termin</th>
             <th>Prio</th>
           </tr>
@@ -56,12 +57,13 @@
         <tbody>
           {% for t in upcoming_tasks %}
           <tr>
+            <td>{{ t.tid }}</td>
             <td><a href="/task/view/{{ t.id }}/">{{ t.betreff }}</a></td>
             <td>{{ t.termin_dt|date:"d.m.Y" }}</td>
             <td>{{ t.prio }}</td>
           </tr>
           {% empty %}
-          <tr><td colspan="4">Keine offenen Aufgaben</td></tr>
+          <tr><td colspan="5">Keine offenen Aufgaben</td></tr>
           {% endfor %}
         </tbody>
       </table>

--- a/otto-ui/core/templates/core/task_archive_listview.html
+++ b/otto-ui/core/templates/core/task_archive_listview.html
@@ -38,6 +38,7 @@
     <table class="table table-striped table-hover table-sm">
         <thead>
             <tr>
+                <th>TID</th>
                 <th>Betreff</th>
                 <th>Typ</th>
                 <th>Status</th>              
@@ -49,6 +50,7 @@
         <tbody>
             {% for task in tasks %}
             <tr>
+                <td>{{ task.tid }}</td>
                 <td><a href="#" class="task-open" data-task-id="{{ task.id }}">{{ task.betreff }}</a></td>
                 <td>
                     <form hx-post="/task/update_typ/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
@@ -89,7 +91,7 @@
                 </td>
             </tr>
             {% empty %}
-            <tr><td colspan="6">Keine abgeschlossenen Aufgaben gefunden.</td></tr>
+            <tr><td colspan="7">Keine abgeschlossenen Aufgaben gefunden.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -31,6 +31,10 @@
         {% csrf_token %}
         <input type="hidden" name="task_id" value="{{ task.id }}">
         <div class="mb-3">
+          <label class="form-label">TID</label>
+          <input class="form-control" type="number" name="tid" value="{{ task.tid }}">
+        </div>
+        <div class="mb-3">
           <label class="form-label">Betreff</label>
           <input class="form-control" type="text" name="betreff" value="{{ task.betreff }}">
         </div>

--- a/otto-ui/core/templates/core/task_listview.html
+++ b/otto-ui/core/templates/core/task_listview.html
@@ -38,6 +38,7 @@
     <table class="table table-striped table-hover table-sm">
         <thead>
             <tr>
+                <th>TID</th>
                 <th>Betreff</th>
                 <th>Typ</th>
                 <th>Status</th>              
@@ -49,6 +50,7 @@
         <tbody>
             {% for task in tasks %}
             <tr>
+                <td>{{ task.tid }}</td>
                 <td><a href="/task/view/{{ task.id }}/">{{ task.betreff }}</a></td>
                 <td>
                     <form hx-post="/task/update_typ/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
@@ -89,7 +91,7 @@
                 </td>
             </tr>
             {% empty %}
-            <tr><td colspan="6">Keine offenen Aufgaben gefunden.</td></tr>
+            <tr><td colspan="7">Keine offenen Aufgaben gefunden.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -263,6 +263,9 @@ def update_task_details(request):
         task["meeting_id"] = request.POST.get("meeting_id") or None
         aufwand = request.POST.get("aufwand")
         task["aufwand"] = int(aufwand) if aufwand and aufwand.isdigit() else 0
+        tid = request.POST.get("tid")
+        if tid and tid.isdigit():
+            task["tid"] = int(tid)
         update_res = requests.put(
             f"{OTTO_API_URL}/tasks/{task_id}",
             headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},


### PR DESCRIPTION
## Summary
- extend Task model with new integer field `tid`
- accept and save `tid` when updating task details
- show `tid` in task detail page and all task tables

## Testing
- `pytest -q`
