### PR TITLE
Add Kanban board for tasks

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("project/<str:project_id>/", views.project_detailview, name="project_detailview"),
     path('task/', views.task_listview, name='task_liste'),
     path('task/archiv/', views.task_archive_listview, name='task_archiv'),
+    path('task/kanban/', views.task_kanban_view, name='task_kanban'),
     path('task/update_status/', views.update_task_status, name='update_task_status'),
     path('task/update_person/', views.update_task_person, name='update_task_person'),
     path('task/update_typ/', views.update_task_typ, name='update_task_typ'),

--- a/otto-ui/core/static/css/kanban.css
+++ b/otto-ui/core/static/css/kanban.css
@@ -1,0 +1,34 @@
+.kanban-board {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+}
+.kanban-column {
+  flex: 1 0 300px;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+  background: #f8f9fa;
+  padding: 0.5rem;
+  border-radius: 4px;
+}
+.kanban-column-header {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+.status-neu {
+  background-color: #e3f2fd;
+}
+.status-in-arbeit {
+  background-color: #fff3cd;
+}
+.status-laufend {
+  background-color: #e2e3e5;
+}
+.status-wartet {
+  background-color: #fde2e2;
+}
+.status-abgeschlossen {
+  background-color: #d4edda;
+}

--- a/otto-ui/core/templates/base.html
+++ b/otto-ui/core/templates/base.html
@@ -84,6 +84,7 @@
           <ul class="dropdown-menu" aria-labelledby="taskDropdown">
             <li><a class="dropdown-item" href="/task/">Offen</a></li>
             <li><a class="dropdown-item" href="/task/archiv/">Archiv</a></li>
+            <li><a class="dropdown-item" href="/task/kanban/">Kanban</a></li>
           </ul>
         </li>
         <li class="nav-item">

--- a/otto-ui/core/templates/core/task_kanban.html
+++ b/otto-ui/core/templates/core/task_kanban.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% load static %}
+{% block content %}
+<link rel="stylesheet" href="{% static 'css/kanban.css' %}">
+<script>
+  window.ottoContext = {
+    type: "task",
+    name: "Kanban Board",
+    id: "",
+    gptFunctions: []
+  }
+</script>
+<div class="kanban-board container-fluid mt-3">
+  {% for status,tasks in grouped_list %}
+  <div class="kanban-column status-{{ status|slugify }}" data-status="{{ status }}">
+    <div class="kanban-column-header">{{ status }}</div>
+    {% for task in tasks %}
+    <div class="card mb-2" draggable="true" data-task-id="{{ task.id }}">
+      <div class="card-body p-2">
+        <div><strong>{{ task.betreff }}</strong></div>
+        <div><small>{{ task.person_name }}</small></div>
+        <div><small>{{ task.termin_formatiert }}</small></div>
+        <a href="/task/view/{{ task.id }}/" class="btn btn-sm btn-primary mt-1">Details</a>
+      </div>
+    </div>
+    {% empty %}
+    <p class="p-2">-</p>
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.kanban-column').forEach(function(col){
+      new Sortable(col, {
+        group: 'tasks',
+        animation: 150,
+        onEnd: function(evt){
+          const taskId = evt.item.dataset.taskId;
+          const newStatus = evt.to.dataset.status;
+          fetch('/task/update_status/', {
+            method: 'POST',
+            headers: {'HX-Request': 'true'},
+            body: new URLSearchParams({task_id: taskId, status: newStatus})
+          });
+        }
+      });
+    });
+  });
+</script>
+{% endblock %}

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -2,6 +2,7 @@ from .auth import login_view, logout_view
 from .tasks import (
     task_listview,
     task_archive_listview,
+    task_kanban_view,
     update_task_status,
     update_task_person,
     update_task_typ,


### PR DESCRIPTION
## Summary
- add `task_kanban_view` and integrate in router
- create kanban template with drag & drop via SortableJS
- style board via new CSS file
- link from navigation

## Testing
- `python manage.py test`