### PR TITLE
Add Kanban filters and toggle

### DIFF
--- a/otto-ui/core/templates/core/task_kanban.html
+++ b/otto-ui/core/templates/core/task_kanban.html
@@ -11,9 +11,21 @@
   }
 </script>
 <div class="container-fluid mt-3">
-  <div class="row mb-2">
-    <div class="col-sm-4">
+  <div class="row mb-2 align-items-center">
+    <div class="col-sm-4 mb-2 mb-sm-0">
       <input type="text" id="kanban-search" class="form-control" placeholder="Suchen...">
+    </div>
+    <div class="col-sm-4 mb-2 mb-sm-0">
+      <select id="kanban-person" class="form-select">
+        <option value="">Alle Agents</option>
+        {% for p in agenten %}
+        <option value="{{ p.id }}">{{ p.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-sm-4 form-check">
+      <input class="form-check-input" type="checkbox" id="toggle-completed" checked>
+      <label class="form-check-label" for="toggle-completed">Abgeschlossen anzeigen</label>
     </div>
   </div>
   <div class="kanban-board">
@@ -21,7 +33,7 @@
   <div class="kanban-column status-{{ status|slugify }}" data-status="{{ status }}">
     <div class="kanban-column-header">{{ status }}</div>
     {% for task in tasks %}
-    <div class="card mb-2" draggable="true" data-task-id="{{ task.id }}">
+    <div class="card mb-2" draggable="true" data-task-id="{{ task.id }}" data-person-id="{{ task.person_id }}">
       <div class="card-body p-2">
         <div><strong>{{ task.betreff }}</strong></div>
         <div><small>👤 {{ task.person_name }}</small></div>
@@ -48,13 +60,27 @@
     }
 
     const searchInput = document.getElementById('kanban-search');
-    if (searchInput) {
-      searchInput.addEventListener('input', function(e) {
-        const q = e.target.value.toLowerCase();
-        document.querySelectorAll('.kanban-column .card').forEach(function(card) {
-          const txt = card.textContent.toLowerCase();
-          card.style.display = txt.indexOf(q) !== -1 ? '' : 'none';
-        });
+    const personSelect = document.getElementById('kanban-person');
+    function applyFilters() {
+      const q = (searchInput ? searchInput.value.toLowerCase() : '');
+      const pid = personSelect ? personSelect.value : '';
+      document.querySelectorAll('.kanban-column .card').forEach(function(card) {
+        const txt = card.textContent.toLowerCase();
+        const matchSearch = txt.indexOf(q) !== -1;
+        const matchPerson = !pid || card.dataset.personId === pid;
+        card.style.display = (matchSearch && matchPerson) ? '' : 'none';
+      });
+    }
+    if (searchInput) searchInput.addEventListener('input', applyFilters);
+    if (personSelect) personSelect.addEventListener('change', applyFilters);
+
+    const toggleCompleted = document.getElementById('toggle-completed');
+    if (toggleCompleted) {
+      toggleCompleted.addEventListener('change', function(e) {
+        const col = document.querySelector('.kanban-column[data-status="✅ abgeschlossen"]');
+        if (col) {
+          col.style.display = e.target.checked ? '' : 'none';
+        }
       });
     }
 

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -125,6 +125,7 @@ def task_kanban_view(request):
     personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
     personen = personen_res.json() if personen_res.status_code == 200 else []
     personen_map = {p.get("id"): p.get("name") for p in personen}
+    agenten = [p for p in personen if p.get("rolle") == "agent"]
 
     grouped = {status: [] for status in status_liste}
     for t in tasks:
@@ -149,6 +150,7 @@ def task_kanban_view(request):
     context = {
         "grouped_list": grouped_list,
         "status_liste": status_liste,
+        "agenten": agenten,
     }
     return render(request, "core/task_kanban.html", context)
 


### PR DESCRIPTION
## Summary
- extend Kanban view with a dropdown of agents and show/hide checkbox for the completed column
- support agent data in the kanban view context
- filter by agent and search query client-side and toggle completed column visibility

## Testing
- `pytest -q`