### PR TITLE
Add project filters to task lists

### DIFF
--- a/otto-ui/core/templates/core/task_archive_listview.html
+++ b/otto-ui/core/templates/core/task_archive_listview.html
@@ -13,13 +13,25 @@
     <h2 class="mb-4">Archiv</h2>
     <div class="card">
     <div class="card-body">
-    <form method="get" class="row mb-3">
+    <form method="get" class="row mb-3 align-items-end">
         <div class="col-sm-4">
             <input type="text" class="form-control" name="q" value="{{ request.GET.q }}" placeholder="Suchen...">
         </div>
+        <div class="col-sm-3">
+            <select class="form-select" name="project_id">
+                <option value="">-- Projekt wählen --</option>
+                {% for projekt in projekte %}
+                    <option value="{{ projekt.id }}" {% if request.GET.project_id == projekt.id %}selected{% endif %}>{{ projekt.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-auto form-check">
+            <input class="form-check-input" type="checkbox" name="without_project" id="withoutProjectArchive" value="1" {% if request.GET.without_project %}checked{% endif %}>
+            <label class="form-check-label" for="withoutProjectArchive">Ohne Projekt</label>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-outline-primary">Suchen</button>
-            {% if request.GET.q %}
+            {% if request.GET.q or request.GET.project_id or request.GET.without_project %}
                 <a href="/task/archiv/" class="btn btn-outline-secondary ms-2">Zurücksetzen</a>
             {% endif %}
         </div>
@@ -98,15 +110,15 @@
     <nav aria-label="Seiten" class="mt-3">
         <ul class="pagination justify-content-center">
             <li class="page-item {% if page <= 1 %}disabled{% endif %}">
-                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}page={{ page|add:-1 }}">Vorherige</a>
+                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.project_id %}project_id={{ request.GET.project_id }}&{% endif %}{% if request.GET.without_project %}without_project={{ request.GET.without_project }}&{% endif %}page={{ page|add:-1 }}">Vorherige</a>
             </li>
             {% for p in page_numbers %}
             <li class="page-item {% if p == page %}active{% endif %}">
-                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}page={{ p }}">{{ p }}</a>
+                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.project_id %}project_id={{ request.GET.project_id }}&{% endif %}{% if request.GET.without_project %}without_project={{ request.GET.without_project }}&{% endif %}page={{ p }}">{{ p }}</a>
             </li>
             {% endfor %}
             <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
-                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}page={{ page|add:1 }}">Nächste</a>
+                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.project_id %}project_id={{ request.GET.project_id }}&{% endif %}{% if request.GET.without_project %}without_project={{ request.GET.without_project }}&{% endif %}page={{ page|add:1 }}">Nächste</a>
             </li>
         </ul>
     </nav>

--- a/otto-ui/core/templates/core/task_listview.html
+++ b/otto-ui/core/templates/core/task_listview.html
@@ -13,13 +13,25 @@
     <h2 class="mb-4">Aufgaben</h2>
     <div class="card">
     <div class="card-body">
-    <form method="get" class="row mb-3">
+    <form method="get" class="row mb-3 align-items-end">
         <div class="col-sm-4">
             <input type="text" class="form-control" name="q" value="{{ request.GET.q }}" placeholder="Suchen...">
         </div>
+        <div class="col-sm-3">
+            <select class="form-select" name="project_id">
+                <option value="">-- Projekt wählen --</option>
+                {% for projekt in projekte %}
+                    <option value="{{ projekt.id }}" {% if request.GET.project_id == projekt.id %}selected{% endif %}>{{ projekt.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-auto form-check">
+            <input class="form-check-input" type="checkbox" name="without_project" id="withoutProject" value="1" {% if request.GET.without_project %}checked{% endif %}>
+            <label class="form-check-label" for="withoutProject">Ohne Projekt</label>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-outline-primary">Suchen</button>
-            {% if request.GET.q %}
+            {% if request.GET.q or request.GET.project_id or request.GET.without_project %}
                 <a href="/task/" class="btn btn-outline-secondary ms-2">Zurücksetzen</a>
             {% endif %}
         </div>
@@ -98,15 +110,15 @@
     <nav aria-label="Seiten" class="mt-3">
         <ul class="pagination justify-content-center">
             <li class="page-item {% if page <= 1 %}disabled{% endif %}">
-                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}page={{ page|add:-1 }}">Vorherige</a>
+                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.project_id %}project_id={{ request.GET.project_id }}&{% endif %}{% if request.GET.without_project %}without_project={{ request.GET.without_project }}&{% endif %}page={{ page|add:-1 }}">Vorherige</a>
             </li>
             {% for p in page_numbers %}
             <li class="page-item {% if p == page %}active{% endif %}">
-                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}page={{ p }}">{{ p }}</a>
+                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.project_id %}project_id={{ request.GET.project_id }}&{% endif %}{% if request.GET.without_project %}without_project={{ request.GET.without_project }}&{% endif %}page={{ p }}">{{ p }}</a>
             </li>
             {% endfor %}
             <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
-                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}page={{ page|add:1 }}">Nächste</a>
+                <a class="page-link" href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.project_id %}project_id={{ request.GET.project_id }}&{% endif %}{% if request.GET.without_project %}without_project={{ request.GET.without_project }}&{% endif %}page={{ page|add:1 }}">Nächste</a>
             </li>
         </ul>
     </nav>

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -20,6 +20,9 @@ def task_listview(request):
     res = requests.get(f"{OTTO_API_URL}/tasks", headers={"x-api-key": OTTO_API_KEY})
     tasks = res.json() if res.status_code == 200 else []
     q = request.GET.get("q", "").lower()
+    project_id = request.GET.get("project_id")
+    without_project = request.GET.get("without_project")
+    without_project = True if without_project else False
     try:
         page = int(request.GET.get("page", 1))
     except ValueError:
@@ -27,12 +30,20 @@ def task_listview(request):
     per_page = 20
     personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
     personen = personen_res.json() if personen_res.status_code == 200 else []
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
 
     offene_tasks = []
     for t in tasks:
         if t.get("status", "").lower() != "✅ abgeschlossen":
             if q and q not in t.get("betreff", "").lower() and q not in t.get("beschreibung", "").lower():
                 continue
+            if project_id:
+                if t.get("project_id") != project_id:
+                    continue
+            elif without_project:
+                if t.get("project_id"):
+                    continue
             termin_str = t.get("termin")
             try:
                 termin_dt = datetime.fromisoformat(termin_str) if termin_str else None
@@ -60,9 +71,12 @@ def task_listview(request):
         "status_liste": status_liste,
         "typ_liste": typ_liste,
         "personen": personen,
+        "projekte": projekte,
         "page": page,
         "total_pages": total_pages,
         "page_numbers": page_numbers,
+        "selected_project": project_id,
+        "without_project": without_project,
     })
 
 
@@ -71,6 +85,9 @@ def task_archive_listview(request):
     res = requests.get(f"{OTTO_API_URL}/tasks", headers={"x-api-key": OTTO_API_KEY})
     tasks = res.json() if res.status_code == 200 else []
     q = request.GET.get("q", "").lower()
+    project_id = request.GET.get("project_id")
+    without_project = request.GET.get("without_project")
+    without_project = True if without_project else False
     try:
         page = int(request.GET.get("page", 1))
     except ValueError:
@@ -78,12 +95,20 @@ def task_archive_listview(request):
     per_page = 20
     personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
     personen = personen_res.json() if personen_res.status_code == 200 else []
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
 
     erledigte_tasks = []
     for t in tasks:
         if t.get("status", "").lower() == "✅ abgeschlossen":
             if q and q not in t.get("betreff", "").lower() and q not in t.get("beschreibung", "").lower():
                 continue
+            if project_id:
+                if t.get("project_id") != project_id:
+                    continue
+            elif without_project:
+                if t.get("project_id"):
+                    continue
             termin_str = t.get("termin")
             try:
                 termin_dt = datetime.fromisoformat(termin_str) if termin_str else None
@@ -111,9 +136,12 @@ def task_archive_listview(request):
         "status_liste": status_liste,
         "typ_liste": typ_liste,
         "personen": personen,
+        "projekte": projekte,
         "page": page,
         "total_pages": total_pages,
         "page_numbers": page_numbers,
+        "selected_project": project_id,
+        "without_project": without_project,
     })
 
 


### PR DESCRIPTION
## Summary
- filter task lists by project affiliation
- allow showing tasks without project
- persist project filters during pagination

## Testing
- `pytest -q`