### PR TITLE
Add Sprint model and Django/FastAPI views

### DIFF
--- a/api/controller/sprint_controller.py
+++ b/api/controller/sprint_controller.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, HTTPException, Depends, Body
+from typing import List
+from bson import ObjectId
+from bson.errors import InvalidId
+from model.sprint import Sprint, SprintListe
+from mongo import sprints_collection, projekte_collection
+from helper import verify_api_key, serialize_mongo
+
+router = APIRouter()
+
+@router.get("/sprints", dependencies=[Depends(verify_api_key)], tags=["Sprint"])
+async def list_sprints():
+    cursor = sprints_collection.find()
+    return [serialize_mongo(s) async for s in cursor]
+
+@router.get("/sprints/{sprint_id}", dependencies=[Depends(verify_api_key)], tags=["Sprint"])
+async def get_sprint(sprint_id: str):
+    try:
+        oid = ObjectId(sprint_id)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Ungültige ID")
+
+    sprint = await sprints_collection.find_one({"_id": oid})
+    if not sprint:
+        raise HTTPException(status_code=404, detail="Sprint nicht gefunden")
+    return serialize_mongo(sprint)
+
+@router.post("/sprints", dependencies=[Depends(verify_api_key)], tags=["Sprint"])
+async def create_sprint(sprint: Sprint):
+    if not await projekte_collection.find_one({"_id": ObjectId(sprint.projekt_id)}):
+        raise HTTPException(status_code=400, detail="Projekt nicht gefunden")
+    result = await sprints_collection.insert_one(sprint.dict())
+    return {"status": "ok", "id": str(result.inserted_id)}
+
+@router.put("/sprints/{sprint_id}", dependencies=[Depends(verify_api_key)], tags=["Sprint"])
+async def update_sprint(sprint_id: str, sprint: Sprint):
+    try:
+        oid = ObjectId(sprint_id)
+    except InvalidId:
+        raise HTTPException(status_code=400, detail="Ungültige ID")
+    if not await projekte_collection.find_one({"_id": ObjectId(sprint.projekt_id)}):
+        raise HTTPException(status_code=400, detail="Projekt nicht gefunden")
+    result = await sprints_collection.replace_one({"_id": oid}, sprint.dict())
+    if result.matched_count == 0:
+        raise HTTPException(status_code=404, detail="Sprint nicht gefunden")
+    return {"status": "aktualisiert"}
+
+@router.delete("/sprints/{sprint_id}", dependencies=[Depends(verify_api_key)], tags=["Sprint"])
+async def delete_sprint(sprint_id: str):
+    try:
+        oid = ObjectId(sprint_id)
+    except InvalidId:
+        raise HTTPException(status_code=400, detail="Ungültige ID")
+    result = await sprints_collection.delete_one({"_id": oid})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=404, detail="Sprint nicht gefunden")
+    return {"status": "gelöscht"}
+
+@router.get("/projekt/{projekt_id}/sprints", dependencies=[Depends(verify_api_key)], tags=["Projekt"])
+async def get_sprints_by_project(projekt_id: str):
+    cursor = sprints_collection.find({"projekt_id": projekt_id})
+    return [serialize_mongo(s) async for s in cursor]

--- a/api/main.py
+++ b/api/main.py
@@ -78,6 +78,12 @@ try:
 except Exception as e:
     print(f"⚠️ Fehler beim Einbinden von message_controller: {e}")
 
+try:
+    from controller.sprint_controller import router as sprint_router
+    app.include_router(sprint_router)
+except Exception as e:
+    print(f"⚠️ Fehler beim Einbinden von sprint_controller: {e}")
+
 def custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema

--- a/api/model/sprint.py
+++ b/api/model/sprint.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
+from datetime import date
+
+class Sprint(BaseModel):
+    name: str
+    projekt_id: str = Field(..., description="ID des zugehörigen Projekts")
+    typ: Literal['minor', 'major']
+    startdatum: date
+    enddatum: date
+    beschreibung: Optional[str] = None
+    status: Literal['neu', 'aktiv', 'abgeschlossen']
+
+class SprintListe(BaseModel):
+    sprints: list[Sprint]

--- a/api/mongo.py
+++ b/api/mongo.py
@@ -13,6 +13,7 @@ db = client.otto  # DB-Name
 projekte_collection = db.projekte
 personen_collection = db.personen
 meeting_collection = db.meeting
+sprints_collection = db.sprints
 users = db["users"]
 messages_collection = db.messages
 db.meetings.delete_many({"id": ""})

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -27,6 +27,8 @@ urlpatterns = [
     path('person/', views.person_listview, name='person_liste'),
     path('person/<str:person_id>/', views.person_detailview, name='person_detail'),
     path('message/<str:message_id>/', views.message_detailview, name='message_detail'),
+    path('sprint/', views.sprint_listview, name='sprint_liste'),
+    path('sprint/<str:sprint_id>/', views.sprint_detailview, name='sprint_detail'),
     path('login/', login_view, name='login'),
     path('logout/', logout_view, name='logout'),
 

--- a/otto-ui/core/const.py
+++ b/otto-ui/core/const.py
@@ -11,3 +11,6 @@ typ_liste = [
     "🔄 Change",
 ]
 projekt_typ = ["Meeting", "Projekt"]
+
+sprint_typ = ["minor", "major"]
+sprint_status = ["neu", "aktiv", "abgeschlossen"]

--- a/otto-ui/core/templates/core/sprint_detailview.html
+++ b/otto-ui/core/templates/core/sprint_detailview.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block content %}
+<script>
+  window.ottoContext = {
+    type: "sprint",
+    name: "{{ sprint.name }}",
+    id: "{{ sprint.id }}"
+  }
+</script>
+<div class="container py-4">
+  <form id="sprintForm">
+    {% csrf_token %}
+    <div class="card">
+      <div class="card-header">{{ sprint.name }}</div>
+      <div class="card-body">
+        <div class="row">
+          <div class="col-12 mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" class="form-control" value="{{ sprint.name }}">
+          </div>
+          <div class="col-12 mb-3">
+            <label class="form-label">Projekt</label>
+            <select name="projekt_id" class="form-select">
+              <option value="">– bitte w\u00e4hlen –</option>
+              {% for p in projekte %}
+              <option value="{{ p.id }}" {% if p.id == sprint.projekt_id %}selected{% endif %}>{{ p.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="col-md-6 mb-3">
+            <label class="form-label">Typ</label>
+            <select name="typ" class="form-select">
+              {% for t in sprint_typ %}
+              <option value="{{ t }}" {% if t == sprint.typ %}selected{% endif %}>{{ t }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="col-md-3 mb-3">
+            <label class="form-label">Startdatum</label>
+            <input type="date" name="startdatum" class="form-control" value="{{ sprint.startdatum }}">
+          </div>
+          <div class="col-md-3 mb-3">
+            <label class="form-label">Enddatum</label>
+            <input type="date" name="enddatum" class="form-control" value="{{ sprint.enddatum }}">
+          </div>
+          <div class="col-12 mb-3">
+            <label class="form-label">Beschreibung</label>
+            <textarea name="beschreibung" class="form-control">{{ sprint.beschreibung }}</textarea>
+          </div>
+          <div class="col-md-6 mb-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select">
+              {% for s in sprint_status %}
+              <option value="{{ s }}" {% if s == sprint.status %}selected{% endif %}>{{ s }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="mt-3">
+      <button type="submit" class="btn btn-outline-primary">💾 Speichern</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/otto-ui/core/templates/core/sprint_listview.html
+++ b/otto-ui/core/templates/core/sprint_listview.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block content %}
+<script>
+  window.ottoContext = {
+    type: "sprint",
+    name: "\u00dcbersicht aller Sprints",
+    id: ""
+  }
+</script>
+<div class="container-fluid">
+  <h2 class="mb-4">Sprints</h2>
+  <form method="get" class="mb-3 d-flex gap-2">
+    <div class="input-group">
+      <input type="text" name="q" class="form-control" placeholder="Suche nach Sprintname" value="{{ request.GET.q }}">
+      <button class="btn btn-outline-secondary" type="submit">Suchen</button>
+    </div>
+    {% if request.GET.q %}
+    <a href="/sprint/" class="btn btn-outline-danger">Zur\u00fccksetzen</a>
+    {% endif %}
+  </form>
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Typ</th>
+        <th>Start</th>
+        <th>Ende</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sprint in sprints %}
+      <tr>
+        <td><a href="/sprint/{{ sprint.id }}/">{{ sprint.name }}</a></td>
+        <td>{{ sprint.status }}</td>
+        <td>{{ sprint.typ }}</td>
+        <td>{{ sprint.startdatum }}</td>
+        <td>{{ sprint.enddatum }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -21,6 +21,7 @@ from .projects import (
 from .meetings import meeting_listview, meeting_detailview, meeting_create
 from .persons import person_listview, person_detailview
 from .messages import message_detailview
+from .sprints import sprint_listview, sprint_detailview
 from django.shortcuts import render
 from .helpers import login_required
 import os

--- a/otto-ui/core/views/sprints.py
+++ b/otto-ui/core/views/sprints.py
@@ -1,0 +1,54 @@
+import os
+import requests
+import json
+from django.shortcuts import render, redirect
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from .helpers import login_required
+from core.const import sprint_typ, sprint_status
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OTTO_API_KEY = os.getenv("OTTO_API_KEY")
+OTTO_API_URL = os.getenv("OTTO_API_URL")
+
+
+@login_required
+def sprint_listview(request):
+    res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = res.json() if res.status_code == 200 else []
+    q = request.GET.get("q", "").lower()
+    if q:
+        sprints = [s for s in sprints if q in s.get("name", "").lower()]
+    return render(request, "core/sprint_listview.html", {"sprints": sprints, "sprint_status": sprint_status})
+
+
+@login_required
+@csrf_exempt
+def sprint_detailview(request, sprint_id):
+    if request.method == "POST":
+        payload = json.loads(request.body)
+        res = requests.get(f"{OTTO_API_URL}/sprints/{sprint_id}", headers={"x-api-key": OTTO_API_KEY})
+        if res.status_code != 200:
+            return JsonResponse({"error": "Sprint nicht gefunden"}, status=404)
+        sprint = res.json()
+        for k, v in payload.items():
+            sprint[k] = v
+        update = requests.put(
+            f"{OTTO_API_URL}/sprints/{sprint_id}",
+            headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+            data=json.dumps(sprint),
+        )
+        return JsonResponse({"success": True}) if update.status_code == 200 else JsonResponse({"error": "Fehler beim Speichern"}, status=500)
+
+    sprint_res = requests.get(f"{OTTO_API_URL}/sprints/{sprint_id}", headers={"x-api-key": OTTO_API_KEY})
+    sprint = sprint_res.json() if sprint_res.status_code == 200 else {}
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    return render(request, "core/sprint_detailview.html", {
+        "sprint": sprint,
+        "projekte": projekte,
+        "sprint_typ": sprint_typ,
+        "sprint_status": sprint_status,
+    })


### PR DESCRIPTION
## Summary
- implement Sprint model and collection
- expose Sprint API endpoints in FastAPI
- include router in main application
- show Sprint constants in UI and add Django views
- templates for Sprint list and detail pages
- hook up new URLs

## Testing
- `python -m py_compile api/model/sprint.py api/controller/sprint_controller.py otto-ui/core/views/sprints.py`
- `python -m py_compile otto-ui/config/urls.py otto-ui/core/views/__init__.py`