### PR TITLE
Add quick team creation

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('person/', views.person_listview, name='person_liste'),
     path('person/<str:person_id>/', views.person_detailview, name='person_detail'),
     path('team/', views.team_listview, name='team_liste'),
+    path('team/new/', views.team_create, name='team_create'),
     path('team/<str:team_id>/', views.team_detailview, name='team_detail'),
     path('message/<str:message_id>/', views.message_detailview, name='message_detail'),
     path('login/', login_view, name='login'),

--- a/otto-ui/core/templates/core/team_listview.html
+++ b/otto-ui/core/templates/core/team_listview.html
@@ -18,7 +18,7 @@
         <th>Name</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody id="teamTableBody">
       {% for t in teams %}
       <tr>
         <td><a href="/team/{{ t.id }}/">{{ t.name }}</a></td>
@@ -28,5 +28,10 @@
       {% endfor %}
     </tbody>
   </table>
+  <form id="addTeamForm" class="d-flex gap-2" hx-post="/team/new/" hx-target="#teamTableBody" hx-swap="beforeend">
+    {% csrf_token %}
+    <input type="text" name="name" class="form-control" placeholder="Neues Team">
+    <button type="submit" class="btn btn-primary">Hinzufügen</button>
+  </form>
 </div>
 {% endblock %}

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -20,7 +20,7 @@ from .projects import (
 )
 from .meetings import meeting_listview, meeting_detailview, meeting_create
 from .persons import person_listview, person_detailview
-from .teams import team_listview, team_detailview
+from .teams import team_listview, team_detailview, team_create
 from .messages import message_detailview
 from django.shortcuts import render
 from .helpers import login_required


### PR DESCRIPTION
## Summary
- enable adding teams from the list view
- implement `team_create` view and routing

## Testing
- `python -m py_compile otto-ui/core/views/teams.py otto-ui/core/views/__init__.py otto-ui/config/urls.py`
- `pytest -q`
