### PR TITLE
Add sprint field to tasks

### DIFF
--- a/api/controller/task_controller.py
+++ b/api/controller/task_controller.py
@@ -5,6 +5,7 @@ from helper import verify_api_key, serialize_mongo
 from mongo import db
 from datetime import datetime, date
 from bson import ObjectId
+from pymongo import ReturnDocument
 
 router = APIRouter()
 
@@ -36,6 +37,9 @@ async def list_tasks():
 async def create_task(task: Task):
     if not await db.personen.find_one({"_id": ObjectId(task.person_id)}):
         raise HTTPException(status_code=400, detail=f"Person mit ID '{task.person_id}' nicht gefunden.")
+    if task.sprint_id:
+        if not await db.sprints.find_one({"_id": ObjectId(task.sprint_id)}):
+            raise HTTPException(status_code=400, detail="Sprint nicht gefunden")
 
     task_dict = convert_dates(task.dict())
     if "tid" not in task_dict:
@@ -60,6 +64,9 @@ async def get_task(task_id: str):
 async def update_task(task_id: str, task: Task):
     if not await db.personen.find_one({"_id": ObjectId(task.person_id)}):
         raise HTTPException(status_code=400, detail=f"Person mit ID '{task.person_id}' nicht gefunden.")
+    if task.sprint_id:
+        if not await db.sprints.find_one({"_id": ObjectId(task.sprint_id)}):
+            raise HTTPException(status_code=400, detail="Sprint nicht gefunden")
 
     task_dict = convert_dates(task.dict())
     result = await db.tasks.update_one({"_id": ObjectId(task_id)}, {"$set": task_dict})

--- a/api/model/task.py
+++ b/api/model/task.py
@@ -15,4 +15,5 @@ class Task(BaseModel):
     termin: Optional[date] = None
     status: str  # z.B. "offen", "in Arbeit", "erledigt"
     project_id: Optional[str] = None
+    sprint_id: Optional[str] = None
     meeting_id: Optional[str] = None

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -188,6 +188,14 @@
       {% endfor %}
     </select>
   </div>
+  <div class="col-12 col-md-3">
+    <select name="sprint_id" class="form-select">
+      <option value="">Sprint wählen</option>
+      {% for s in sprints %}
+      <option value="{{ s.id }}">{{ s.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
   <div class="col-12 col-md-1">
     <button type="submit" class="btn btn-success w-100">➕</button>
   </div>

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -50,7 +50,16 @@
             <option value="{{ projekt.id }}" {% if task.project_id == projekt.id %}selected{% endif %}>{{ projekt.name }}</option>
             {% endfor %}
           </select>
-        </div>      
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Sprint</label>
+          <select class="form-select" name="sprint_id">
+            <option value="">-- Kein Sprint --</option>
+            {% for sprint in sprints %}
+            <option value="{{ sprint.id }}" {% if task.sprint_id == sprint.id %}selected{% endif %}>{{ sprint.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
         <div class="mb-3">
           <label class="form-label">Zuständig</label>
           <select class="form-select" name="person_id">

--- a/otto-ui/core/templates/core/task_kanban.html
+++ b/otto-ui/core/templates/core/task_kanban.html
@@ -50,6 +50,9 @@
         <div><strong>{{ task.betreff }}</strong></div>
         <div><small>👤 {{ task.person_name }}</small></div>
         <div><small>📅 {{ task.termin_formatiert }}</small></div>
+        {% if task.sprint_name %}
+        <div><small>🏁 {{ task.sprint_name }}</small></div>
+        {% endif %}
         <a href="/task/view/{{ task.id }}/" class="btn btn-sm btn-primary mt-1">Details</a>
       </div>
     </div>

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -102,6 +102,8 @@ def project_detailview(request, project_id):
     messages = messages_res.json() if messages_res.status_code == 200 else []
     personen_res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
     personen = personen_res.json() if personen_res.status_code == 200 else []
+    sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = sprints_res.json() if sprints_res.status_code == 200 else []
 
     return render(request, "core/project_detailview.html", {
         "projekt": projekt,
@@ -111,7 +113,8 @@ def project_detailview(request, project_id):
         "dateien": dateien,
         "status_liste": status_liste,
         "prio_liste": prio_liste,
-        "typ_liste": typ_liste
+        "typ_liste": typ_liste,
+        "sprints": sprints
     })
 
 
@@ -149,7 +152,8 @@ def project_create_task(request):
             "prio": data.get("prio", "mittel"),
             "status": data.get("status", "Offen"),
             "termin": data.get("termin"),
-            "project_id": data["project_id"]
+            "project_id": data["project_id"],
+            "sprint_id": data.get("sprint_id")
         }
     )
     return JsonResponse(response.json(), status=response.status_code)

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -32,6 +32,9 @@ def task_listview(request):
     personen = personen_res.json() if personen_res.status_code == 200 else []
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = sprints_res.json() if sprints_res.status_code == 200 else []
+    sprint_map = {s.get("id"): s.get("name") for s in sprints}
 
     offene_tasks = []
     for t in tasks:
@@ -50,6 +53,7 @@ def task_listview(request):
             except ValueError:
                 termin_dt = None
             t["termin_dt"] = termin_dt
+            t["sprint_name"] = sprint_map.get(t.get("sprint_id"))
             offene_tasks.append(t)
 
     offene_tasks.sort(key=lambda x: x["termin_dt"] or datetime.max)
@@ -115,6 +119,7 @@ def task_archive_listview(request):
             except ValueError:
                 termin_dt = None
             t["termin_dt"] = termin_dt
+            t["sprint_name"] = sprint_map.get(t.get("sprint_id"))
             erledigte_tasks.append(t)
 
     erledigte_tasks.sort(key=lambda x: x["termin_dt"] or datetime.max)
@@ -157,6 +162,9 @@ def task_kanban_view(request):
 
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = sprints_res.json() if sprints_res.status_code == 200 else []
+    sprint_map = {s.get("id"): s.get("name") for s in sprints}
 
     grouped = {status: [] for status in status_liste}
     for t in tasks:
@@ -171,6 +179,7 @@ def task_kanban_view(request):
         t["termin_dt"] = termin_dt
         t["termin_formatiert"] = termin_dt.strftime("%d.%m.%Y") if termin_dt else "-"
         t["person_name"] = personen_map.get(t.get("person_id"), "-")
+        t["sprint_name"] = sprint_map.get(t.get("sprint_id"))
         grouped[status].append(t)
 
     for lst in grouped.values():
@@ -183,6 +192,7 @@ def task_kanban_view(request):
         "status_liste": status_liste,
         "agenten": agenten,
         "projekte": projekte,
+        "sprints": sprints,
     }
     return render(request, "core/task_kanban.html", context)
 
@@ -213,6 +223,8 @@ def task_create(request):
     personen = personen_res.json() if personen_res.status_code == 200 else []
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = meetings_res.json() if meetings_res.status_code == 200 else []
 
@@ -223,6 +235,7 @@ def task_create(request):
         "prio_liste": prio_liste,
         "status_liste": status_liste,
         "typ_liste": typ_liste,
+        "sprints": sprints,
     })
 
 
@@ -384,6 +397,8 @@ def task_detail_or_update(request, task_id):
     personen = personen_res.json() if personen_res.status_code == 200 else []
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = meetings_res.json() if meetings_res.status_code == 200 else []
     return render(request, "core/task_detailview.html", {
@@ -394,6 +409,7 @@ def task_detail_or_update(request, task_id):
         "prio_liste": prio_liste,
         "status_liste": status_liste,
         "typ_liste": typ_liste,
+        "sprints": sprints,
     })
 
 @login_required
@@ -423,6 +439,8 @@ def task_pageview(request, task_id):
     personen = personen_res.json() if personen_res.status_code == 200 else []
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
+    sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = meetings_res.json() if meetings_res.status_code == 200 else []
     return render(request, "core/task_detailpage.html", {
@@ -433,4 +451,5 @@ def task_pageview(request, task_id):
         "prio_liste": prio_liste,
         "status_liste": status_liste,
         "typ_liste": typ_liste,
+        "sprints": sprints,
     })


### PR DESCRIPTION
## Summary
- add `sprint_id` to task model and API
- validate sprint when creating or updating tasks
- display sprint in task form and allow selection
- show sprint name on Kanban cards
- allow new tasks to select sprint in project page
- fetch sprint info in related views

## Testing
- `python -m py_compile $(git ls-files '*.py')`