### PR TITLE
Add Requester field to tasks

### DIFF
--- a/api/controller/task_controller.py
+++ b/api/controller/task_controller.py
@@ -37,6 +37,8 @@ async def list_tasks():
 async def create_task(task: Task):
     if not await db.personen.find_one({"_id": ObjectId(task.person_id)}):
         raise HTTPException(status_code=400, detail=f"Person mit ID '{task.person_id}' nicht gefunden.")
+    if task.requester_id and not await db.personen.find_one({"_id": ObjectId(task.requester_id)}):
+        raise HTTPException(status_code=400, detail=f"Requester mit ID '{task.requester_id}' nicht gefunden.")
     if task.sprint_id:
         if not await db.sprints.find_one({"_id": ObjectId(task.sprint_id)}):
             raise HTTPException(status_code=400, detail="Sprint nicht gefunden")
@@ -64,6 +66,8 @@ async def get_task(task_id: str):
 async def update_task(task_id: str, task: Task):
     if not await db.personen.find_one({"_id": ObjectId(task.person_id)}):
         raise HTTPException(status_code=400, detail=f"Person mit ID '{task.person_id}' nicht gefunden.")
+    if task.requester_id and not await db.personen.find_one({"_id": ObjectId(task.requester_id)}):
+        raise HTTPException(status_code=400, detail=f"Requester mit ID '{task.requester_id}' nicht gefunden.")
     if task.sprint_id:
         if not await db.sprints.find_one({"_id": ObjectId(task.sprint_id)}):
             raise HTTPException(status_code=400, detail="Sprint nicht gefunden")

--- a/api/model/task.py
+++ b/api/model/task.py
@@ -8,6 +8,7 @@ class Task(BaseModel):
     beschreibung: Optional[str] = ""
     tasktype: Optional[str] = Field(None, description="Typ der Aufgabe, z.B. 'Aufgabe', 'Feature', 'Bug', 'Ticket', 'Requirement', 'Sonstiges'")
     person_id: str = Field(..., description="ID der verantwortlichen Person (personen.id)")
+    requester_id: Optional[str] = Field(None, description="ID der anfordernden Person (personen.id)")
     aufwand: int
     notizen: Optional[str] = ""
     prio: Optional[str]  # z.B. "hoch", "mittel", "niedrig"

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -132,6 +132,7 @@
           <th>Aufwand</th>
           <th>Termin</th>
           <th>Zuständig</th>
+          <th>Requester</th>
           <th></th>
         </tr>
       </thead>
@@ -162,8 +163,15 @@
           </td>
          <td>
   <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="person_id">
-    {% for p in personen %}
+    {% for p in agenten %}
       <option value="{{ p.id }}" {% if p.id == task.person_id %}selected{% endif %}>{{ p.name }}</option>
+    {% endfor %}
+  </select>
+</td>
+         <td>
+  <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="requester_id">
+    {% for p in personen %}
+      <option value="{{ p.id }}" {% if p.id == task.requester_id %}selected{% endif %}>{{ p.name }}</option>
     {% endfor %}
   </select>
 </td>
@@ -196,6 +204,14 @@
   <div class="col-12 col-md-3">
     <select name="person_id" class="form-select">
       <option value="">Zuständig wählen</option>
+      {% for p in agenten %}
+      <option value="{{ p.id }}">{{ p.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-12 col-md-3">
+    <select name="requester_id" class="form-select">
+      <option value="">Requester wählen</option>
       {% for p in personen %}
       <option value="{{ p.id }}">{{ p.name }}</option>
       {% endfor %}

--- a/otto-ui/core/templates/core/task_archive_listview.html
+++ b/otto-ui/core/templates/core/task_archive_listview.html
@@ -55,6 +55,7 @@
                 <th>Typ</th>
                 <th>Status</th>              
                 <th>Zuständig</th>
+                <th>Requester</th>
                 <th>Termin</th>
                 <th></th>
             </tr>
@@ -88,8 +89,18 @@
                     <form hx-post="/task/update_person/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
                         <input type="hidden" name="task_id" value="{{ task.id }}">
                         <select class="form-select form-select-sm" name="person_id">
-                            {% for person in personen %}
+                            {% for person in agenten %}
                                 <option value="{{ person.id }}" {% if task.person_id and task.person_id == person.id %}selected{% endif %}>{{ person.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                </td>
+                <td>
+                    <form hx-post="/task/update/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
+                        <input type="hidden" name="task_id" value="{{ task.id }}">
+                        <select class="form-select form-select-sm" name="requester_id">
+                            {% for person in personen %}
+                                <option value="{{ person.id }}" {% if task.requester_id and task.requester_id == person.id %}selected{% endif %}>{{ person.name }}</option>
                             {% endfor %}
                         </select>
                     </form>
@@ -103,7 +114,7 @@
                 </td>
             </tr>
             {% empty %}
-            <tr><td colspan="7">Keine abgeschlossenen Aufgaben gefunden.</td></tr>
+            <tr><td colspan="8">Keine abgeschlossenen Aufgaben gefunden.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -63,8 +63,16 @@
         <div class="mb-3">
           <label class="form-label">Zuständig</label>
           <select class="form-select" name="person_id">
-            {% for person in personen %}
+            {% for person in agenten %}
             <option value="{{ person.id }}" {% if task.person_id == person.id %}selected{% endif %}>{{ person.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Requester</label>
+          <select class="form-select" name="requester_id">
+            {% for person in personen %}
+            <option value="{{ person.id }}" {% if task.requester_id == person.id %}selected{% endif %}>{{ person.name }}</option>
             {% endfor %}
           </select>
         </div>

--- a/otto-ui/core/templates/core/task_listview.html
+++ b/otto-ui/core/templates/core/task_listview.html
@@ -55,6 +55,7 @@
                 <th>Typ</th>
                 <th>Status</th>              
                 <th>Zuständig</th>
+                <th>Requester</th>
                 <th>Termin</th>
                 <th></th>
             </tr>
@@ -88,8 +89,18 @@
                     <form hx-post="/task/update_person/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
                         <input type="hidden" name="task_id" value="{{ task.id }}">
                         <select class="form-select form-select-sm" name="person_id">
-                            {% for person in personen %}
+                            {% for person in agenten %}
                                 <option value="{{ person.id }}" {% if task.person_id and task.person_id == person.id %}selected{% endif %}>{{ person.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </form>
+                </td>
+                <td>
+                    <form hx-post="/task/update/" hx-trigger="change" hx-target="closest td" hx-swap="outerHTML">
+                        <input type="hidden" name="task_id" value="{{ task.id }}">
+                        <select class="form-select form-select-sm" name="requester_id">
+                            {% for person in personen %}
+                                <option value="{{ person.id }}" {% if task.requester_id and task.requester_id == person.id %}selected{% endif %}>{{ person.name }}</option>
                             {% endfor %}
                         </select>
                     </form>
@@ -103,7 +114,7 @@
                 </td>
             </tr>
             {% empty %}
-            <tr><td colspan="7">Keine offenen Aufgaben gefunden.</td></tr>
+            <tr><td colspan="8">Keine offenen Aufgaben gefunden.</td></tr>
             {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- add `requester_id` to Task model
- validate requester in API
- add helpers for sorted agent/person lists
- filter assignee options to agents/admins
- add requester dropdowns in task templates
- include requester when creating tasks via projects

## Testing
- `pytest -q`