### PR TITLE
Add task search & pagination in project detail

### DIFF
--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -121,6 +121,17 @@
   </ul>
 <div class="tab-content mt-3">
      <div class="tab-pane fade show active" id="tasks" role="tabpanel">
+  <form method="get" class="row mb-3">
+    <div class="col-sm-4">
+      <input type="text" class="form-control" name="task_q" value="{{ task_q }}" placeholder="Aufgaben suchen...">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-outline-primary">Suchen</button>
+      {% if task_q %}
+        <a href="?" class="btn btn-outline-secondary ms-2">Zurücksetzen</a>
+      {% endif %}
+    </div>
+  </form>
   {% if tasks %}
     <table class="table table-sm table-striped">
       <thead>
@@ -186,6 +197,21 @@
         {% endfor %}
       </tbody>
     </table>
+    <nav aria-label="Seiten" class="mt-3">
+      <ul class="pagination justify-content-center">
+        <li class="page-item {% if task_page <= 1 %}disabled{% endif %}">
+          <a class="page-link" href="?task_q={{ task_q }}&task_page={{ task_page|add:-1 }}">Vorherige</a>
+        </li>
+        {% for p in task_page_numbers %}
+        <li class="page-item {% if p == task_page %}active{% endif %}">
+          <a class="page-link" href="?task_q={{ task_q }}&task_page={{ p }}">{{ p }}</a>
+        </li>
+        {% endfor %}
+        <li class="page-item {% if task_page >= task_total_pages %}disabled{% endif %}">
+          <a class="page-link" href="?task_q={{ task_q }}&task_page={{ task_page|add:1 }}">Nächste</a>
+        </li>
+      </ul>
+    </nav>
     <h6 class="mt-4">Neue Aufgabe hinzufügen</h6>
 <form id="taskForm" class="row g-2">
   {% csrf_token %}


### PR DESCRIPTION
## Summary
- add search form and pager to project detail view
- filter tasks server-side and paginate 10 per page

## Testing
- `python -m py_compile otto-ui/core/views/projects.py`
