### PR TITLE
Add project field to Sprint views and filter tasks

### DIFF
--- a/otto-ui/core/templates/core/sprint_listview.html
+++ b/otto-ui/core/templates/core/sprint_listview.html
@@ -24,6 +24,7 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Projekt</th>
         <th>Status</th>
         <th>Typ</th>
         <th>Start</th>
@@ -34,6 +35,7 @@
       {% for sprint in sprints %}
       <tr>
         <td><a href="/sprint/{{ sprint.id }}/">{{ sprint.name }}</a></td>
+        <td>{{ sprint.projekt_name }}</td>
         <td>{{ sprint.status }}</td>
         <td>{{ sprint.typ }}</td>
         <td>{{ sprint.startdatum|slice:10 }}</td>

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -141,6 +141,25 @@ function getCookie(name){
 }
 const form = document.getElementById('taskForm');
 const successBox = document.getElementById('saveSuccess');
+const allSprints = JSON.parse('{{ sprints|escapejs }}');
+const sprintSelect = form.querySelector('select[name="sprint_id"]');
+const projectSelect = form.querySelector('select[name="project_id"]');
+const initialSprint = '{{ task.sprint_id|default:"" }}';
+
+function filterSprints() {
+  const projectId = projectSelect.value;
+  sprintSelect.innerHTML = '<option value="">-- Kein Sprint --</option>';
+  allSprints.filter(s => s.projekt_id === projectId).forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = s.id;
+    opt.textContent = s.name;
+    if (s.id === initialSprint) opt.selected = true;
+    sprintSelect.appendChild(opt);
+  });
+}
+
+projectSelect.addEventListener('change', filterSprints);
+document.addEventListener('DOMContentLoaded', filterSprints);
 
 function saveTask() {
   const data = {};

--- a/otto-ui/core/views/sprints.py
+++ b/otto-ui/core/views/sprints.py
@@ -18,9 +18,17 @@ OTTO_API_URL = os.getenv("OTTO_API_URL")
 def sprint_listview(request):
     res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
     sprints = res.json() if res.status_code == 200 else []
+
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    projekt_map = {p.get("id"): p.get("name") for p in projekte}
+    for s in sprints:
+        s["projekt_name"] = projekt_map.get(s.get("projekt_id"), "")
+
     q = request.GET.get("q", "").lower()
     if q:
         sprints = [s for s in sprints if q in s.get("name", "").lower()]
+
     return render(request, "core/sprint_listview.html", {"sprints": sprints, "sprint_status": sprint_status})
 
 

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -347,6 +347,7 @@ def update_task_details(request):
         task["person_id"] = request.POST.get("person_id")
         task["requester_id"] = request.POST.get("requester_id")
         task["project_id"] = request.POST.get("project_id") or None
+        task["sprint_id"] = request.POST.get("sprint_id") or None
         aufwand = request.POST.get("aufwand")
         task["aufwand"] = int(aufwand) if aufwand and aufwand.isdigit() else 0
         tid = request.POST.get("tid")


### PR DESCRIPTION
## Summary
- show project names in sprint list view
- filter available sprint options by selected project
- store sprint assignments when updating tasks

## Testing
- `python -m py_compile otto-ui/core/views/sprints.py otto-ui/core/views/tasks.py`
- `cd otto-ui && python manage.py test`