### PR TITLE
Fix sprint JSON parsing error

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -123,6 +123,7 @@
     </div>
   </div>
   <div id="saveSuccess" class="alert alert-success d-none">Gespeichert!</div>
+  {{ sprints|json_script:"sprints-data" }}
 </div>
 <script>
 function getCookie(name){
@@ -140,8 +141,8 @@ function getCookie(name){
   return cookieValue;
 }
 const form = document.getElementById('taskForm');
-const successBox = document.getElementById('saveSuccess');
-const allSprints = JSON.parse('{{ sprints|escapejs }}');
+  const successBox = document.getElementById('saveSuccess');
+  const allSprints = JSON.parse(document.getElementById('sprints-data').textContent);
 const sprintSelect = form.querySelector('select[name="sprint_id"]');
 const projectSelect = form.querySelector('select[name="project_id"]');
 const initialSprint = '{{ task.sprint_id|default:"" }}';


### PR DESCRIPTION
## Summary
- output sprint data using `json_script` for safe JSON
- parse sprint data from script element instead of invalid template string

## Testing
- `pytest -q`
- `python otto-ui/manage.py test`
