### PR TITLE
Show tasks in sprint detail view

### DIFF
--- a/api/controller/task_controller.py
+++ b/api/controller/task_controller.py
@@ -103,3 +103,9 @@ async def delete_task(task_id: str):
 async def get_tasks_by_project(project_id: str):
     cursor = db.tasks.find({"project_id": project_id})
     return [serialize_mongo(task) async for task in cursor]
+
+@router.get("/sprint/{sprint_id}/tasks", dependencies=[Depends(verify_api_key)], tags=["Sprint"])
+async def get_tasks_by_sprint(sprint_id: str):
+    """Return all tasks that belong to the given sprint."""
+    cursor = db.tasks.find({"sprint_id": sprint_id})
+    return [serialize_mongo(task) async for task in cursor]

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('sprint/', views.sprint_listview, name='sprint_liste'),
     path('sprint/new/', views.sprint_create, name='sprint_create'),
     path('sprint/delete/', views.delete_sprint, name='delete_sprint'),
+    path('sprint/createtask/', views.sprint_create_task, name='sprint_create_task'),
     path('sprint/<str:sprint_id>/', views.sprint_detailview, name='sprint_detail'),
     path('login/', login_view, name='login'),
     path('logout/', logout_view, name='logout'),

--- a/otto-ui/core/templates/core/sprint_detailview.html
+++ b/otto-ui/core/templates/core/sprint_detailview.html
@@ -75,6 +75,135 @@
     
     <div id="saveSuccess" class="alert alert-success mt-3 d-none">Gespeichert!</div>
   </form>
+
+  <hr class="my-4">
+
+  <form method="get" class="row mb-3">
+    <div class="col-sm-4">
+      <input type="text" class="form-control" name="task_q" value="{{ task_q }}" placeholder="Aufgaben suchen...">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-outline-primary">Suchen</button>
+      {% if task_q %}
+        <a href="?" class="btn btn-outline-secondary ms-2">Zurücksetzen</a>
+      {% endif %}
+    </div>
+  </form>
+  {% if tasks %}
+    <table class="table table-sm table-striped">
+      <thead>
+        <tr>
+          <th>TID</th>
+          <th>Betreff</th>
+          <th>Status</th>
+          <th>Typ</th>
+          <th>Termin</th>
+          <th>Zuständig</th>
+          <th>Requester</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for task in tasks %}
+        <tr id="task-{{ task.id }}">
+          <td>{{ task.tid }}</td>
+          <td><a href="/task/view/{{ task.id }}/">{{ task.betreff }}</a></td>
+          <td>
+            <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="status">
+              {% for s in status_liste %}
+                <option value="{{ s }}" {% if s == task.status %}selected{% endif %}>{{ s }}</option>
+              {% endfor %}
+            </select>
+          </td>
+          <td>
+            <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="typ">
+              {% for t in typ_liste %}
+                <option value="{{ t }}" {% if t == task.typ %}selected{% endif %}>{{ t }}</option>
+              {% endfor %}
+            </select>
+          </td>
+          <td>
+            <input type="date" class="form-control form-control-sm auto-save" data-task-id="{{ task.id }}" data-field="termin" value="{{ task.termin|default_if_none:''|slice:':10' }}">
+          </td>
+          <td>
+            <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="person_id">
+              {% for p in agenten %}
+                <option value="{{ p.id }}" {% if p.id == task.person_id %}selected{% endif %}>{{ p.name }}</option>
+              {% endfor %}
+            </select>
+          </td>
+          <td>
+            <select class="form-select form-select-sm auto-save" data-task-id="{{ task.id }}" data-field="requester_id">
+              <option value="">-- Kein Requester --</option>
+              {% for p in personen %}
+                <option value="{{ p.id }}" {% if p.id == task.requester_id %}selected{% endif %}>{{ p.name }}</option>
+              {% endfor %}
+            </select>
+          </td>
+          <td>
+            <form hx-post="/task/delete/" hx-confirm="Wirklich löschen?" hx-target="closest tr" hx-swap="outerHTML">
+              <input type="hidden" name="task_id" value="{{ task.id }}">
+              <button type="submit" class="btn btn-sm btn-outline-danger">🗑️</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <nav aria-label="Seiten" class="mt-3">
+      <ul class="pagination justify-content-center">
+        <li class="page-item {% if task_page <= 1 %}disabled{% endif %}">
+          <a class="page-link" href="?task_q={{ task_q }}&task_page={{ task_page|add:-1 }}">Vorherige</a>
+        </li>
+        {% for p in task_page_numbers %}
+        <li class="page-item {% if p == task_page %}active{% endif %}">
+          <a class="page-link" href="?task_q={{ task_q }}&task_page={{ p }}">{{ p }}</a>
+        </li>
+        {% endfor %}
+        <li class="page-item {% if task_page >= task_total_pages %}disabled{% endif %}">
+          <a class="page-link" href="?task_q={{ task_q }}&task_page={{ task_page|add:1 }}">Nächste</a>
+        </li>
+      </ul>
+    </nav>
+    <h6 class="mt-4">Neue Aufgabe hinzufügen</h6>
+    <form id="taskForm" class="row g-2">
+      {% csrf_token %}
+      <div class="col-12 col-md-4">
+        <input type="text" name="betreff" class="form-control" placeholder="Betreff" required>
+      </div>
+      <div class="col-6 col-md-2">
+        <input type="date" name="termin" class="form-control">
+      </div>
+      <div class="col-6 col-md-2">
+        <select name="status" class="form-select">
+          {% for s in status_liste %}
+          <option value="{{ s }}">{{ s }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-12 col-md-3">
+        <select name="person_id" class="form-select">
+          <option value="">Zuständig wählen</option>
+          {% for p in agenten %}
+          <option value="{{ p.id }}">{{ p.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-12 col-md-3">
+        <select name="requester_id" class="form-select">
+          <option value="">-- Kein Requester --</option>
+          {% for p in personen %}
+          <option value="{{ p.id }}">{{ p.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-12 col-md-1">
+        <button type="submit" class="btn btn-success w-100">➕</button>
+      </div>
+    </form>
+  {% else %}
+    <p>Keine Tasks vorhanden.</p>
+  {% endif %}
 </div>
 <script>
   function getCookie(name) {
@@ -165,5 +294,43 @@
       });
     }
   });
+
+  document.querySelectorAll('.auto-save').forEach(el => {
+    el.addEventListener('change', () => {
+      const taskId = el.dataset.taskId;
+      const field = el.dataset.field;
+      const value = el.value;
+
+      fetch(`/task/view/${taskId}/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCookie('csrftoken'),
+        },
+        body: JSON.stringify({ [field]: value })
+      }).then(r => { if(!r.ok) alert('Fehler beim Speichern'); });
+    });
+  });
+
+  const taskForm = document.getElementById('taskForm');
+  if (taskForm) {
+    taskForm.addEventListener('submit', function (e) {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(this));
+      data.sprint_id = window.ottoContext.id;
+      data.project_id = '{{ sprint.projekt_id }}';
+      data.status = data.status || 'Offen';
+      data.zuständig = 'Otto';
+
+      fetch('/sprint/createtask/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCookie('csrftoken')
+        },
+        body: JSON.stringify(data)
+      }).then(r => { if (r.ok) location.reload(); else alert('Fehler beim Erstellen der Aufgabe'); });
+    });
+  }
 </script>
 {% endblock %}

--- a/otto-ui/core/views/sprints.py
+++ b/otto-ui/core/views/sprints.py
@@ -5,13 +5,22 @@ from django.shortcuts import render, redirect
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from .helpers import login_required
-from core.const import sprint_typ, sprint_status
+from core.const import sprint_typ, sprint_status, status_liste, typ_liste
+from django.views.decorators.http import require_POST
 from dotenv import load_dotenv
 
 load_dotenv()
 
 OTTO_API_KEY = os.getenv("OTTO_API_KEY")
 OTTO_API_URL = os.getenv("OTTO_API_URL")
+
+
+def load_person_lists():
+    res = requests.get(f"{OTTO_API_URL}/personen", headers={"x-api-key": OTTO_API_KEY})
+    personen = res.json() if res.status_code == 200 else []
+    personen_sorted = sorted(personen, key=lambda p: p.get("name", ""))
+    agenten_sorted = [p for p in personen_sorted if p.get("rolle") in ["agent", "admin"]]
+    return personen_sorted, agenten_sorted
 
 
 @login_required
@@ -54,11 +63,53 @@ def sprint_detailview(request, sprint_id):
     sprint = sprint_res.json() if sprint_res.status_code == 200 else {}
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+
+    tasks_res = requests.get(
+        f"{OTTO_API_URL}/sprint/{sprint_id}/tasks",
+        headers={"x-api-key": OTTO_API_KEY},
+    )
+    tasks = tasks_res.json() if tasks_res.status_code == 200 else []
+
+    task_q = request.GET.get("task_q", "").lower()
+    try:
+        task_page = int(request.GET.get("task_page", 1))
+    except ValueError:
+        task_page = 1
+    task_per_page = 10
+
+    filtered_tasks = []
+    for t in tasks:
+        if task_q:
+            if task_q not in t.get("betreff", "").lower() and task_q not in t.get("beschreibung", "").lower():
+                continue
+        filtered_tasks.append(t)
+
+    task_total_pages = max(1, (len(filtered_tasks) + task_per_page - 1) // task_per_page)
+    if task_page < 1:
+        task_page = 1
+    if task_page > task_total_pages:
+        task_page = task_total_pages
+    start = (task_page - 1) * task_per_page
+    end = start + task_per_page
+    paginated_tasks = filtered_tasks[start:end]
+    task_page_numbers = range(1, task_total_pages + 1)
+
+    personen, agenten = load_person_lists()
+
     return render(request, "core/sprint_detailview.html", {
         "sprint": sprint,
         "projekte": projekte,
         "sprint_typ": sprint_typ,
         "sprint_status": sprint_status,
+        "tasks": paginated_tasks,
+        "personen": personen,
+        "agenten": agenten,
+        "status_liste": status_liste,
+        "typ_liste": typ_liste,
+        "task_page": task_page,
+        "task_total_pages": task_total_pages,
+        "task_page_numbers": task_page_numbers,
+        "task_q": task_q,
     })
 
 
@@ -104,3 +155,28 @@ def delete_sprint(request):
             return redirect("/sprint/")
         return JsonResponse({"error": "Fehler beim L\u00f6schen."}, status=500)
     return JsonResponse({"error": "Ung\u00fcltige Methode."}, status=405)
+
+
+@require_POST
+@csrf_exempt
+def sprint_create_task(request):
+    """Create a new task directly from the sprint view."""
+    data = json.loads(request.body)
+    response = requests.post(
+        f"{OTTO_API_URL}/tasks",
+        headers={"x-api-key": OTTO_API_KEY},
+        json={
+            "betreff": data["betreff"],
+            "beschreibung": "",
+            "zuständig": data.get("zuständig", "Otto"),
+            "person_id": data.get("person_id"),
+            "requester_id": data.get("requester_id"),
+            "aufwand": 1,
+            "prio": data.get("prio", "mittel"),
+            "status": data.get("status", "Offen"),
+            "termin": data.get("termin"),
+            "project_id": data.get("project_id"),
+            "sprint_id": data["sprint_id"],
+        }
+    )
+    return JsonResponse(response.json(), status=response.status_code)


### PR DESCRIPTION
## Summary
- add API route to list tasks of a sprint
- expand sprint detail view to display and create tasks
- expose sprint task creation endpoint

## Testing
- `python -m py_compile api/controller/task_controller.py otto-ui/core/views/sprints.py otto-ui/config/urls.py`
- `pytest -q`