### PR TITLE
Fix missing sprint_create_task export

### DIFF
--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -21,7 +21,13 @@ from .projects import (
 )
 from .persons import person_listview, person_detailview, person_create, delete_person
 from .messages import message_detailview
-from .sprints import sprint_listview, sprint_detailview, sprint_create, delete_sprint
+from .sprints import (
+    sprint_listview,
+    sprint_detailview,
+    sprint_create,
+    sprint_create_task,
+    delete_sprint,
+)
 from django.shortcuts import render
 from .helpers import login_required
 import os


### PR DESCRIPTION
## Summary
- import `sprint_create_task` in `core.views.__init__` to allow URL binding

## Testing
- `python manage.py check`
- `python ../task_tid.py test` *(fails: localhost:27017 connection refused)*