### PR TITLE
Add similar tasks search

### DIFF
--- a/api/chroma.py
+++ b/api/chroma.py
@@ -24,3 +24,45 @@ def upsert_task(task: dict):
         ids=[task["id"]],
     )
 
+
+def similar_tasks(query_text: str, exclude_id: str, limit: int = 5):
+    """Return a list of tasks similar to the given query text.
+
+    Parameters
+    ----------
+    query_text: str
+        Text used as the query for the semantic search.
+    exclude_id: str
+        ID of the task that initiated the search. The task with this ID is
+        excluded from the result list if returned by Chroma.
+    limit: int, optional
+        Maximum number of similar tasks to return. Defaults to 5.
+
+    Returns
+    -------
+    list[dict]
+        Each dict contains ``id``, ``betreff`` and ``projekt`` keys.
+    """
+
+    res = collection.query(
+        query_texts=[query_text],
+        n_results=limit + 1,
+        include=["metadatas", "ids"],
+    )
+
+    tasks = []
+    for task_id, meta in zip(res.get("ids", [[ ]])[0], res.get("metadatas", [[ ]])[0]):
+        if task_id == exclude_id:
+            continue
+        full = meta.get("full", {}) if meta else {}
+        tasks.append(
+            {
+                "id": task_id,
+                "betreff": full.get("betreff"),
+                "projekt": full.get("projekt", {}).get("name"),
+            }
+        )
+        if len(tasks) >= limit:
+            break
+    return tasks
+

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -123,6 +123,23 @@
     </div>
   </div>
   <div id="saveSuccess" class="alert alert-success d-none">Gespeichert!</div>
+  {% if similar_tasks %}
+  <div class="card mb-3">
+    <div class="card-header">
+      <h5 class="mb-0">Ähnliche Aufgaben</h5>
+    </div>
+    <div class="card-body p-2">
+      <ul class="list-unstyled mb-0">
+        {% for t in similar_tasks %}
+        <li>
+          <a href="/task/view/{{ t.id }}/">{{ t.betreff }}</a>
+          {% if t.projekt %}<span class="text-muted">({{ t.projekt }})</span>{% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
   {{ sprints|json_script:"sprints-data" }}
 </div>
 <script>

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -475,6 +475,11 @@ def task_pageview(request, task_id):
     sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = meetings_res.json() if meetings_res.status_code == 200 else []
+    similar_res = requests.get(
+        f"{OTTO_API_URL}/tasks/{task_id}/similar",
+        headers={"x-api-key": OTTO_API_KEY},
+    )
+    similar_tasks = similar_res.json() if similar_res.status_code == 200 else []
     return render(request, "core/task_detailpage.html", {
         "task": task,
         "personen": personen,
@@ -485,4 +490,5 @@ def task_pageview(request, task_id):
         "status_liste": status_liste,
         "typ_liste": typ_liste,
         "sprints": sprints,
+        "similar_tasks": similar_tasks,
     })


### PR DESCRIPTION
## Summary
- enable ChromaDB similarity search
- expose API endpoint for similar tasks
- display similar tasks in task detail page

## Testing
- `python -m py_compile api/chroma.py api/controller/task_controller.py otto-ui/core/views/tasks.py`