### PR TITLE
Fix invalid Chroma include

### DIFF
--- a/api/chroma.py
+++ b/api/chroma.py
@@ -48,7 +48,7 @@ def similar_tasks(query_text: str, exclude_id: str, limit: int = 5):
     res = collection.query(
         query_texts=[query_text],
         n_results=limit + 1,
-        include=["metadatas", "ids"],
+        include=["metadatas"],
     )
 
     tasks = []


### PR DESCRIPTION
## Summary
- remove `ids` from the include list when querying Chroma

This avoids a `ValueError` from `chromadb` complaining that `ids` is not a valid include option.

## Testing
- `git status --short`