### PR TITLE
Fix similar_tasks metadata

### DIFF
--- a/api/chroma.py
+++ b/api/chroma.py
@@ -20,7 +20,8 @@ def upsert_task(task: dict):
             "bearbeiter": task.get("person", {}).get("name"),
             "status": task.get("status"),
             "prio": task.get("prio"),
-            "typ": task.get("typ")
+            "typ": task.get("typ"),
+            "full": task,
         }],
         ids=[task["id"]],
     )


### PR DESCRIPTION
## Summary
- store full task info in ChromaDB metadata so `similar_tasks` can show titles and projects

## Testing
- `pytest -q`
- `python -m py_compile api/chroma.py`
