### PR TITLE
Add message status and listview

### DIFF
--- a/api/model/message.py
+++ b/api/model/message.py
@@ -14,4 +14,7 @@ class Message(BaseModel):
     cc: Optional[List[EmailStr]] = None
     message: str  # HTML Inhalt
     direction: Literal["in", "out"]
+    status: Literal["gesendet", "neu", "fehler"] = "neu"
     project_id: Optional[str] = None
+    task_id: Optional[str] = None
+    sprint_id: Optional[str] = None

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('person/new/', views.person_create, name='person_create'),
     path('person/delete/', views.delete_person, name='delete_person'),
     path('person/<str:person_id>/', views.person_detailview, name='person_detail'),
+    path('message/', views.message_listview, name='message_liste'),
     path('message/<str:message_id>/', views.message_detailview, name='message_detail'),
     path('sprint/', views.sprint_listview, name='sprint_liste'),
     path('sprint/new/', views.sprint_create, name='sprint_create'),

--- a/otto-ui/core/templates/base.html
+++ b/otto-ui/core/templates/base.html
@@ -75,7 +75,10 @@
         </li>
         <li class="nav-item">
           <a class="nav-link text-white" href="/projekt/">Projekte</a>
-        </li>       
+        </li>
+        <li class="nav-item">
+          <a class="nav-link text-white" href="/message/">Nachrichten</a>
+        </li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle text-white" href="#" id="taskDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Aufgaben</a>
           <ul class="dropdown-menu" aria-labelledby="taskDropdown">

--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -9,6 +9,16 @@
       <p><strong>Datum:</strong> {{ message.datum }}</p>
       <p><strong>To:</strong> {{ message.to|join:', ' }}</p>
       <p><strong>Cc:</strong> {{ message.cc|default_if_none:''|join:', ' }}</p>
+      <p><strong>Status:</strong> {{ message.status }}</p>
+      {% if message.project_id %}
+      <p><strong>Projekt:</strong> {{ message.project_id }}</p>
+      {% endif %}
+      {% if message.task_id %}
+      <p><strong>Task:</strong> {{ message.task_id }}</p>
+      {% endif %}
+      {% if message.sprint_id %}
+      <p><strong>Sprint:</strong> {{ message.sprint_id }}</p>
+      {% endif %}
       <div class="mt-3 border p-3" style="background:white;">
         {{ message.message|safe }}
       </div>

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container-fluid">
+  <div class="row" style="height: calc(100vh - 120px);">
+    <div class="col-4 border-end overflow-auto">
+      <ul class="nav nav-pills mb-3">
+        <li class="nav-item"><a class="nav-link {% if folder == 'in' %}active{% endif %}" href="?folder=in">Posteingang</a></li>
+        <li class="nav-item"><a class="nav-link {% if folder == 'out' %}active{% endif %}" href="?folder=out">Gesendet</a></li>
+      </ul>
+      <div class="list-group">
+        {% for m in messages %}
+        <a href="?folder={{ folder }}&message_id={{ m.id }}" class="list-group-item list-group-item-action {% if selected and selected.id == m.id %}active{% endif %}">
+          <div class="d-flex w-100 justify-content-between">
+            <h6 class="mb-1">{{ m.subject }}</h6>
+            <small>{{ m.datum|slice:":10" }}</small>
+          </div>
+          <small>{{ m.to|join:', ' }}</small>
+        </a>
+        {% empty %}
+        <p class="m-2">Keine Nachrichten.</p>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="col-8 overflow-auto" id="detailPane">
+      {% if selected %}
+      <div class="card">
+        <div class="card-header">{{ selected.subject }}</div>
+        <div class="card-body">
+          <p><strong>Datum:</strong> {{ selected.datum }}</p>
+          <p><strong>To:</strong> {{ selected.to|join:', ' }}</p>
+          <p><strong>Cc:</strong> {{ selected.cc|default_if_none:''|join:', ' }}</p>
+          <p><strong>Status:</strong> {{ selected.status }}</p>
+          {% if selected.project_id %}<p><strong>Projekt:</strong> {{ selected.project_id }}</p>{% endif %}
+          {% if selected.task_id %}<p><strong>Task:</strong> {{ selected.task_id }}</p>{% endif %}
+          {% if selected.sprint_id %}<p><strong>Sprint:</strong> {{ selected.sprint_id }}</p>{% endif %}
+          <div class="mt-3 border p-3" style="background:white;">{{ selected.message|safe }}</div>
+        </div>
+      </div>
+      {% else %}
+      <p class="m-2">Bitte eine Nachricht auswählen.</p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -20,7 +20,7 @@ from .projects import (
     project_upload_file,
 )
 from .persons import person_listview, person_detailview, person_create, delete_person
-from .messages import message_detailview
+from .messages import message_detailview, message_listview
 from .sprints import (
     sprint_listview,
     sprint_detailview,

--- a/otto-ui/core/views/messages.py
+++ b/otto-ui/core/views/messages.py
@@ -12,6 +12,28 @@ OTTO_API_URL = os.getenv("OTTO_API_URL")
 
 
 @login_required
+def message_listview(request):
+    folder = request.GET.get("folder", "in")
+    selected_id = request.GET.get("message_id")
+
+    res = requests.get(f"{OTTO_API_URL}/messages", headers={"x-api-key": OTTO_API_KEY})
+    msgs = res.json() if res.status_code == 200 else []
+
+    messages = [m for m in msgs if m.get("direction") == ("in" if folder == "in" else "out")]
+
+    selected = None
+    if selected_id:
+        res_det = requests.get(f"{OTTO_API_URL}/messages/{selected_id}", headers={"x-api-key": OTTO_API_KEY})
+        if res_det.status_code == 200:
+            selected = res_det.json()
+
+    return render(request, "core/message_listview.html", {
+        "messages": messages,
+        "folder": folder,
+        "selected": selected,
+    })
+
+@login_required
 def message_detailview(request, message_id):
     res = requests.get(
         f"{OTTO_API_URL}/messages/{message_id}",


### PR DESCRIPTION
## Summary
- extend `Message` model with status, task/sprint optional ids
- add list view for messages with inbox & sent split
- show new fields in message detail
- expose list view via URLs and add nav entry

## Testing
- `python otto-ui/manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683a9660ed4483298166c6950b42d55b