### PR TITLE
Add completion tracking for tasks

### DIFF
--- a/api/controller/task_controller.py
+++ b/api/controller/task_controller.py
@@ -30,7 +30,7 @@ async def get_next_tid():
     return counter["seq"]
 
 def convert_dates(task_dict):
-    for key in ["termin"]:
+    for key in ["termin", "erledigt"]:
         if isinstance(task_dict.get(key), date):
             task_dict[key] = datetime.combine(task_dict[key], datetime.min.time())
     return task_dict

--- a/api/model/task.py
+++ b/api/model/task.py
@@ -14,6 +14,7 @@ class Task(BaseModel):
     prio: Optional[str]  # z.B. "hoch", "mittel", "niedrig"
     typ: Optional[str] = None
     termin: Optional[date] = None
+    erledigt: Optional[date] = None
     status: str  # z.B. "offen", "in Arbeit", "erledigt"
     project_id: Optional[str] = None
     sprint_id: Optional[str] = None

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -20,6 +20,9 @@
           <button type="submit" form="taskForm" class="btn btn-outline-secondary">💾 Speichern</button>
           <button id="saveCloseBtn" type="button" class="btn btn-outline-secondary">💾 Speichern &amp; Schließen</button>
         </div>
+        <div class="btn-group me-2" role="group">
+          <button id="doneBtn" type="button" class="btn btn-outline-success">✅ Erledigt</button>
+        </div>
         <div class="btn-group" role="group">
           <button id="deleteBtn" type="button" class="btn btn-outline-danger">🗑️ Löschen</button>
         </div>
@@ -88,6 +91,10 @@
             <div class="mb-3">
               <label class="form-label">Termin</label>
               <input class="form-control" type="date" name="termin" value="{{ task.termin|default_if_none:''|slice:':10' }}">
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Erledigt am</label>
+              <input class="form-control" type="date" name="erledigt" value="{{ task.erledigt|default_if_none:''|slice:':10' }}">
             </div>
             <div class="mb-3">
               <label class="form-label">Status</label>
@@ -209,6 +216,13 @@ form.addEventListener('submit', function(e){
 document.getElementById('backBtn').addEventListener('click', () => history.back());
 
 document.getElementById('saveCloseBtn').addEventListener('click', () => {
+  saveTask().then(ok => { if(ok) history.back(); });
+});
+
+document.getElementById('doneBtn').addEventListener('click', () => {
+  form.elements['status'].value = '✅ abgeschlossen';
+  const today = new Date().toISOString().slice(0,10);
+  form.elements['erledigt'].value = today;
   saveTask().then(ok => { if(ok) history.back(); });
 });
 

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -348,6 +348,7 @@ def update_task_details(request):
         task["requester_id"] = request.POST.get("requester_id")
         task["project_id"] = request.POST.get("project_id") or None
         task["sprint_id"] = request.POST.get("sprint_id") or None
+        task["erledigt"] = request.POST.get("erledigt") or None
         aufwand = request.POST.get("aufwand")
         task["aufwand"] = int(aufwand) if aufwand and aufwand.isdigit() else 0
         tid = request.POST.get("tid")
@@ -399,7 +400,7 @@ def task_detail_or_update(request, task_id):
                         value = int(value)
                     else:
                         continue
-                elif key == "termin" and value == "":
+                elif key in ["termin", "erledigt"] and value == "":
                     value = None
                 task[key] = value
             update = requests.put(
@@ -454,7 +455,7 @@ def task_pageview(request, task_id):
                         value = int(value)
                     else:
                         continue
-                elif key == "termin" and value == "":
+                elif key in ["termin", "erledigt"] and value == "":
                     value = None
                 task[key] = value
             update = requests.put(


### PR DESCRIPTION
## Summary
- extend `Task` model with `erledigt` date
- handle `erledigt` date conversion in API
- update task detail view to show and set completion date
- add toolbar button to mark tasks as completed

## Testing
- `python -m py_compile api/model/task.py api/controller/task_controller.py otto-ui/core/views/tasks.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a9728ea148329ba364387ef8c9964