### PR TITLE
Add send button to message views

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('person/<str:person_id>/', views.person_detailview, name='person_detail'),
     path('message/', views.message_listview, name='message_liste'),
     path('message/<str:message_id>/', views.message_detailview, name='message_detail'),
+    path('message/send/', views.send_message, name='message_send'),
     path('sprint/', views.sprint_listview, name='sprint_liste'),
     path('sprint/new/', views.sprint_create, name='sprint_create'),
     path('sprint/delete/', views.delete_sprint, name='delete_sprint'),

--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -1,6 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="container py-4">
+  <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar">
+    <form method="post" action="/message/send/" class="btn-group" role="group">
+      {% csrf_token %}
+      <input type="hidden" name="message_id" value="{{ message.id }}">
+      <button type="submit" class="btn btn-outline-primary" {% if message.direction != 'out' or message.status == 'gesendet' %}disabled{% endif %}>📧 Senden</button>
+    </form>
+  </div>
   <div class="card">
     <div class="card-header">
       {{ message.subject }}

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -23,6 +23,13 @@
     </div>
     <div class="col-8 overflow-auto" id="detailPane">
       {% if selected %}
+      <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar">
+        <form method="post" action="/message/send/" class="btn-group" role="group">
+          {% csrf_token %}
+          <input type="hidden" name="message_id" value="{{ selected.id }}">
+          <button type="submit" class="btn btn-outline-primary" {% if selected.direction != 'out' or selected.status == 'gesendet' %}disabled{% endif %}>📧 Senden</button>
+        </form>
+      </div>
       <div class="card">
         <div class="card-header">{{ selected.subject }}</div>
         <div class="card-body">

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -20,7 +20,7 @@ from .projects import (
     project_upload_file,
 )
 from .persons import person_listview, person_detailview, person_create, delete_person
-from .messages import message_detailview, message_listview
+from .messages import message_detailview, message_listview, send_message
 from .sprints import (
     sprint_listview,
     sprint_detailview,


### PR DESCRIPTION
## Summary
- add `send_message` Django view and route
- add toolbar with send button in message detail and list views
- enable graph API url via new environment variable

## Testing
- `pytest -q`
- `python manage.py check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683a9e0689448329b5ee7b065228d729