### PR TITLE
Implement inbox fetching using Graph API

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -21,3 +21,4 @@ SITE_ID = "6de60bff-46b2-4c09-b690-651e0d0ab8f3"
 DRIVE_ID = "b!_wvmbbJGCUy2kGUeDQq48wGoU_ggXVtOoCg4ZWpY2DYICqDfnPOvSrDLdC6yvpNC"
 FOLDER = "Otto/Projekte/"
 GRAPH_URL = "https://graph.microsoft.com/v1.0"
+GRAPH_API_URL = os.getenv("GRAPH_API_URL", "https://graph.isarlabs.de")

--- a/api/controller/message_controller.py
+++ b/api/controller/message_controller.py
@@ -4,6 +4,10 @@ from bson import ObjectId
 from helper import verify_api_key, serialize_mongo
 from mongo import db
 from model.message import Message
+import os
+import httpx
+from datetime import datetime
+from config import API_KEY as INTERNAL_API_KEY, GRAPH_API_URL
 
 router = APIRouter()
 
@@ -28,3 +32,38 @@ async def get_message(message_id: str):
 async def get_messages_by_project(project_id: str):
     cursor = db.messages.find({"project_id": project_id}).sort("datum", -1)
     return [serialize_mongo(m) async for m in cursor]
+
+
+@router.post("/messages/fetch", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def fetch_inbox():
+    """Fetch messages from the external inbox and store them."""
+    headers = {"x-api-key": INTERNAL_API_KEY}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.get(f"{GRAPH_API_URL}/mail/inbox", headers=headers)
+        resp.raise_for_status()
+        msgs = resp.json()
+
+        inserted = []
+        for m in msgs:
+            if await db.messages.find_one({"message_id": m.get("id")}):
+                continue
+
+            doc = {
+                "datum": datetime.fromisoformat(m.get("receivedDateTime")),
+                "subject": m.get("subject", ""),
+                "to": [r["emailAddress"]["address"] for r in m.get("toRecipients", [])],
+                "cc": [r["emailAddress"]["address"] for r in m.get("ccRecipients", [])] or None,
+                "message": m.get("body", {}).get("content", ""),
+                "direction": "in",
+                "status": "gesendet",
+                "message_id": m.get("id"),
+                "conversation_id": m.get("conversationId"),
+            }
+
+            result = await db.messages.insert_one(doc)
+            inserted.append(str(result.inserted_id))
+
+            await client.post(f"{GRAPH_API_URL}/mail/{m.get('id')}/archive", headers=headers)
+
+    return {"inserted": inserted}
+

--- a/api/model/message.py
+++ b/api/model/message.py
@@ -18,3 +18,5 @@ class Message(BaseModel):
     project_id: Optional[str] = None
     task_id: Optional[str] = None
     sprint_id: Optional[str] = None
+    message_id: Optional[str] = None
+    conversation_id: Optional[str] = None

--- a/graph/config.py
+++ b/graph/config.py
@@ -13,6 +13,7 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 TENANT_ID = os.getenv("TENANT_ID")
 MAIL_FROM = "Christian.Angermeier@isartec.de"
 MAIL_TO = os.getenv("MAIL_TO")
+MAIL_INBOX = "otto.pa@isartec.de"
 SITE_ID = "6de60bff-46b2-4c09-b690-651e0d0ab8f3"
 DRIVE_ID = "b!_wvmbbJGCUy2kGUeDQq48wGoU_ggXVtOoCg4ZWpY2DYICqDfnPOvSrDLdC6yvpNC"
 FOLDER = "Otto/Projekte/"


### PR DESCRIPTION
## Summary
- extend Message model with Graph identifiers
- configure Graph API URLs and inbox account
- add endpoints to fetch inbox and archive mails in Graph service
- add API endpoint to import inbox messages and store them

## Testing
- `python -m py_compile api/controller/message_controller.py api/model/message.py graph/controller/mail.py graph/config.py api/config.py`

------
https://chatgpt.com/codex/tasks/task_b_683aa66d170483298eeb5992aac460c0