### PR TITLE
Fix message fetching and add UI button

### DIFF
--- a/api/controller/message_controller.py
+++ b/api/controller/message_controller.py
@@ -48,8 +48,11 @@ async def fetch_inbox():
             if await db.messages.find_one({"message_id": m.get("id")}):
                 continue
 
+            dt_str = m.get("receivedDateTime")
+            if dt_str:
+                dt_str = dt_str.replace("Z", "+00:00")
             doc = {
-                "datum": datetime.fromisoformat(m.get("receivedDateTime")),
+                "datum": datetime.fromisoformat(dt_str) if dt_str else datetime.utcnow(),
                 "subject": m.get("subject", ""),
                 "to": [r["emailAddress"]["address"] for r in m.get("toRecipients", [])],
                 "cc": [r["emailAddress"]["address"] for r in m.get("ccRecipients", [])] or None,

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path('message/new/', views.message_create, name='message_create'),
     path('message/', views.message_listview, name='message_liste'),
     path('message/send/', views.send_message, name='message_send'),
+    path('message/fetch/', views.fetch_messages, name='message_fetch'),
     path('message/<str:message_id>/', views.message_detailview, name='message_detail'),
     path('sprint/', views.sprint_listview, name='sprint_liste'),
     path('sprint/new/', views.sprint_create, name='sprint_create'),

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -22,14 +22,20 @@
       </div>
     </div>
     <div class="col-8 overflow-auto" id="detailPane">
-      {% if selected %}
       <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar">
+        <form method="post" action="/message/fetch/" class="btn-group me-2" role="group">
+          {% csrf_token %}
+          <button type="submit" class="btn btn-outline-secondary">🔄 Abrufen</button>
+        </form>
+        {% if selected %}
         <form method="post" action="/message/send/" class="btn-group" role="group">
           {% csrf_token %}
           <input type="hidden" name="message_id" value="{{ selected.id }}">
           <button type="submit" class="btn btn-outline-primary" {% if selected.direction != 'out' or selected.status == 'gesendet' %}disabled{% endif %}>📧 Senden</button>
         </form>
+        {% endif %}
       </div>
+      {% if selected %}
       <div class="card">
         <div class="card-header">{{ selected.subject }}</div>
         <div class="card-body">

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -20,7 +20,13 @@ from .projects import (
     project_upload_file,
 )
 from .persons import person_listview, person_detailview, person_create, delete_person
-from .messages import message_detailview, message_listview, send_message, message_create
+from .messages import (
+    message_detailview,
+    message_listview,
+    send_message,
+    message_create,
+    fetch_messages,
+)
 from .sprints import (
     sprint_listview,
     sprint_detailview,

--- a/otto-ui/core/views/messages.py
+++ b/otto-ui/core/views/messages.py
@@ -203,3 +203,23 @@ def send_message(request):
         return JsonResponse({"error": "Fehler beim Senden."}, status=500)
 
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
+
+
+@login_required
+@csrf_exempt
+def fetch_messages(request):
+    """Trigger the backend to fetch new inbox messages."""
+    if request.method != "POST":
+        return JsonResponse({"error": "Ungültige Methode."}, status=405)
+
+    res = requests.post(
+        f"{OTTO_API_URL}/messages/fetch",
+        headers={"x-api-key": OTTO_API_KEY},
+    )
+
+    if res.status_code == 200:
+        if request.headers.get("HX-Request") == "true":
+            return HttpResponse("")
+        return redirect(request.META.get("HTTP_REFERER", "/message/"))
+
+    return JsonResponse({"error": "Fehler beim Abrufen."}, status=500)


### PR DESCRIPTION
## Summary
- parse inbox timestamps with timezone
- add backend endpoint for fetching inbox messages
- expose fetch endpoint through Django URLs
- import new view and include fetch button in inbox toolbar

## Testing
- `python3 -m py_compile api/controller/message_controller.py otto-ui/core/views/messages.py otto-ui/core/views/__init__.py otto-ui/config/urls.py`

------
https://chatgpt.com/codex/tasks/task_b_683aa96c4cc88329b35499d3a6f9b349