### PR TITLE
Display sender in message views

### DIFF
--- a/api/controller/message_controller.py
+++ b/api/controller/message_controller.py
@@ -54,6 +54,7 @@ async def fetch_inbox():
             doc = {
                 "datum": datetime.fromisoformat(dt_str) if dt_str else datetime.utcnow(),
                 "subject": m.get("subject", ""),
+                "sender": m.get("from", {}).get("emailAddress", {}).get("address"),
                 "to": [r["emailAddress"]["address"] for r in m.get("toRecipients", [])],
                 "cc": [r["emailAddress"]["address"] for r in m.get("ccRecipients", [])] or None,
                 "message": m.get("body", {}).get("content", ""),

--- a/api/model/message.py
+++ b/api/model/message.py
@@ -10,6 +10,7 @@ class Message(BaseModel):
 
     datum: datetime
     subject: str
+    sender: Optional[EmailStr] = None
     to: List[EmailStr]
     cc: Optional[List[EmailStr]] = None
     message: str  # HTML Inhalt

--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -14,6 +14,7 @@
     </div>
     <div class="card-body">
       <p><strong>Datum:</strong> {{ message.datum }}</p>
+      <p><strong>From:</strong> {{ message.sender|default:message.from }}</p>
       <p><strong>To:</strong> {{ message.to|join:', ' }}</p>
       <p><strong>Cc:</strong> {{ message.cc|default_if_none:''|join:', ' }}</p>
       <p><strong>Status:</strong> {{ message.status }}</p>

--- a/otto-ui/core/templates/core/message_editview.html
+++ b/otto-ui/core/templates/core/message_editview.html
@@ -45,6 +45,10 @@
           <label class="form-label">Cc</label>
           <input type="text" name="cc" class="form-control" value="{{ message.cc|default_if_none:''|join:', ' }}">
         </div>
+        <div class="mb-3">
+          <label class="form-label">From</label>
+          <input type="text" name="sender" class="form-control" value="{{ message.sender|default:message.from }}" {% if message.direction == 'in' %}readonly{% endif %}>
+        </div>
         <textarea id="editor" name="message" class="form-control">{{ message.message|safe }}</textarea>
       </div>
     </div>

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -40,6 +40,7 @@
         <div class="card-header">{{ selected.subject }}</div>
         <div class="card-body">
           <p><strong>Datum:</strong> {{ selected.datum }}</p>
+          <p><strong>From:</strong> {{ selected.sender|default:selected.from }}</p>
           <p><strong>To:</strong> {{ selected.to|join:', ' }}</p>
           <p><strong>Cc:</strong> {{ selected.cc|default_if_none:''|join:', ' }}</p>
           <p><strong>Status:</strong> {{ selected.status }}</p>


### PR DESCRIPTION
## Summary
- extend `Message` model with `sender` field
- capture sender when fetching inbox messages
- show sender information in message detail, edit, and list views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683aaeb4b1b083298f13caa641fbe3b1