### PR TITLE
Fix sender field display for messages

### DIFF
--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -14,7 +14,15 @@
     </div>
     <div class="card-body">
       <p><strong>Datum:</strong> {{ message.datum }}</p>
-      <p><strong>From:</strong> {{ message.sender|default:message.from }}</p>
+      <p><strong>From:</strong>
+        {% if message.sender %}
+          {{ message.sender }}
+        {% elif message.from %}
+          {{ message.from }}
+        {% else %}
+          -
+        {% endif %}
+      </p>
       <p><strong>To:</strong> {{ message.to|join:', ' }}</p>
       <p><strong>Cc:</strong> {{ message.cc|default_if_none:''|join:', ' }}</p>
       <p><strong>Status:</strong> {{ message.status }}</p>

--- a/otto-ui/core/templates/core/message_editview.html
+++ b/otto-ui/core/templates/core/message_editview.html
@@ -47,7 +47,7 @@
         </div>
         <div class="mb-3">
           <label class="form-label">From</label>
-          <input type="text" name="sender" class="form-control" value="{{ message.sender|default:message.from }}" {% if message.direction == 'in' %}readonly{% endif %}>
+          <input type="text" name="sender" class="form-control" value="{% if message.sender %}{{ message.sender }}{% elif message.from %}{{ message.from }}{% endif %}" {% if message.direction == 'in' %}readonly{% endif %}>
         </div>
         <textarea id="editor" name="message" class="form-control">{{ message.message|safe }}</textarea>
       </div>

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -40,7 +40,15 @@
         <div class="card-header">{{ selected.subject }}</div>
         <div class="card-body">
           <p><strong>Datum:</strong> {{ selected.datum }}</p>
-          <p><strong>From:</strong> {{ selected.sender|default:selected.from }}</p>
+          <p><strong>From:</strong>
+            {% if selected.sender %}
+              {{ selected.sender }}
+            {% elif selected.from %}
+              {{ selected.from }}
+            {% else %}
+              -
+            {% endif %}
+          </p>
           <p><strong>To:</strong> {{ selected.to|join:', ' }}</p>
           <p><strong>Cc:</strong> {{ selected.cc|default_if_none:''|join:', ' }}</p>
           <p><strong>Status:</strong> {{ selected.status }}</p>


### PR DESCRIPTION
## Summary
- avoid VariableDoesNotExist errors when sender info is missing
- show fallback '-' if sender/from not present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683ab209adf48329b86b2b6ef830df1a