### PR TITLE
Add delete endpoint and adjust message delete icon

### DIFF
--- a/api/controller/message_controller.py
+++ b/api/controller/message_controller.py
@@ -132,3 +132,18 @@ async def update_message(message_id: str, message: Message):
         raise HTTPException(status_code=404, detail="Message not found")
     return {"status": "aktualisiert"}
 
+
+@router.delete("/messages/{message_id}", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def delete_message(message_id: str):
+    """Delete a message by its MongoDB identifier."""
+    try:
+        oid = ObjectId(message_id)
+    except InvalidId:
+        raise HTTPException(status_code=400, detail="Ungültige ID")
+
+    result = await db.messages.delete_one({"_id": oid})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"status": "deleted"}
+
+

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -16,16 +16,15 @@
             <small>{{ m.datum|slice:":10" }}</small>
           </div>
           <small class="pe-4">{{ m.to|join:', ' }}</small>
-          <form
+          <a
             hx-post="/message/delete/"
+            hx-vals='{"message_id": "{{ m.id }}"}'
             hx-confirm="Wirklich löschen?"
             hx-target="closest .message-item"
             hx-swap="outerHTML"
-            class="position-absolute bottom-0 end-0 m-1"
-          >
-            <input type="hidden" name="message_id" value="{{ m.id }}">
-            <button type="submit" class="btn btn-sm btn-outline-danger">❌</button>
-          </form>
+            class="position-absolute bottom-0 end-0 m-1 text-danger text-decoration-none"
+            style="font-size: 12px; width: 12px; height: 12px; display: inline-block;"
+            >❌</a>
         </div>
         {% empty %}
         <p class="m-2">Keine Nachrichten.</p>


### PR DESCRIPTION
## Summary
- create DELETE endpoint for messages in the API
- use compact anchor link for deleting messages in the message list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_683ab956dbe88329bfac7adeb1674fc0