### PR TITLE
Fix delete icon not clickable

### DIFF
--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -23,7 +23,7 @@
             hx-target="closest .message-item"
             hx-swap="outerHTML"
             class="position-absolute bottom-0 end-0 m-1 text-danger text-decoration-none"
-            style="font-size: 12px; width: 12px; height: 12px; display: inline-block;"
+            style="font-size: 12px; width: 12px; height: 12px; display: inline-block; z-index: 2;"
             >❌</a>
         </div>
         {% empty %}


### PR DESCRIPTION
## Summary
- make the delete icon in the message list clickable by raising its z-index

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683abb28403083298f35ff1f3d254baa