### PR TITLE
Show attachments in message views

### DIFF
--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -38,6 +38,16 @@
       <div class="mt-3 border p-3" style="background:white;">
         {{ message.message|safe }}
       </div>
+      {% if message.attachments %}
+      <div class="mt-3">
+        <strong>Anhänge:</strong>
+        <ul class="list-unstyled">
+          {% for url in message.attachments %}
+          <li><a href="{{ url }}" target="_blank">📎 {{ url|basename }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/otto-ui/core/templates/core/message_editview.html
+++ b/otto-ui/core/templates/core/message_editview.html
@@ -50,6 +50,16 @@
           <input type="text" name="sender" class="form-control" value="{% if message.sender %}{{ message.sender }}{% elif message.from %}{{ message.from }}{% endif %}" {% if message.direction == 'in' %}readonly{% endif %}>
         </div>
         <textarea id="editor" name="message" class="form-control">{{ message.message|safe }}</textarea>
+        {% if message.attachments %}
+        <div class="mt-3">
+          <strong>Anhänge:</strong>
+          <ul class="list-unstyled">
+            {% for url in message.attachments %}
+            <li><a href="{{ url }}" target="_blank">📎 {{ url|basename }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
       </div>
     </div>
   </form>

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -66,6 +66,16 @@
           {% if selected.task_id %}<p><strong>Task:</strong> {{ selected.task_id }}</p>{% endif %}
           {% if selected.sprint_id %}<p><strong>Sprint:</strong> {{ selected.sprint_id }}</p>{% endif %}
           <div class="mt-3 border p-3" style="background:white;">{{ selected.message|safe }}</div>
+          {% if selected.attachments %}
+          <div class="mt-3">
+            <strong>Anhänge:</strong>
+            <ul class="list-unstyled">
+              {% for url in selected.attachments %}
+              <li><a href="{{ url }}" target="_blank">📎 {{ url|basename }}</a></li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
         </div>
       </div>
       {% else %}

--- a/otto-ui/core/templatetags/format_tags.py
+++ b/otto-ui/core/templatetags/format_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from datetime import datetime
+from urllib.parse import urlparse, unquote
 
 register = template.Library()
 
@@ -21,3 +22,13 @@ def filesizeformat(value):
             return f"{value:.1f} {unit}"
         value /= 1024.0
     return f"{value:.1f} PB"
+
+@register.filter
+def basename(value: str):
+    """Return the last path component of a URL."""
+    try:
+        path = urlparse(value).path
+        name = path.rsplit('/', 1)[-1]
+        return unquote(name) or value
+    except Exception:
+        return value


### PR DESCRIPTION
## Summary
- display attachment links in message list, detail and edit views
- add a template filter to extract filenames from URLs

## Testing
- `pytest -q`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683abc029abc8329902bb637b607c033