### PR TITLE
Fix invalid filter in message templates

### DIFF
--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load format_tags %}
 {% block content %}
 <div class="container py-4">
   <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar">

--- a/otto-ui/core/templates/core/message_editview.html
+++ b/otto-ui/core/templates/core/message_editview.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load format_tags %}
 {% block content %}
 <script>
   window.ottoContext = {

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load format_tags %}
 {% block content %}
 <div class="container-fluid">
   <div class="row" style="height: calc(100vh - 120px);">


### PR DESCRIPTION
## Summary
- load `format_tags` in message templates so the `basename` filter works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683abd27a00483298f848debe6bd0102