### PR TITLE
Add message vectorization with Qdrant

### DIFF
--- a/api/controller/message_controller.py
+++ b/api/controller/message_controller.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from typing import List
+import asyncio
 from bson import ObjectId
 from helper import (
     verify_api_key,
@@ -10,6 +11,7 @@ from helper import (
 from bson.errors import InvalidId
 from mongo import db
 from model.message import Message
+from qdrant_utils import upsert_message_to_qdrant, qdrant_similar_messages
 import os
 import httpx
 from datetime import datetime
@@ -22,7 +24,9 @@ router = APIRouter()
 @router.post("/messages", dependencies=[Depends(verify_api_key)], tags=["Message"])
 async def create_message(message: Message):
     result = await db.messages.insert_one(message.dict())
-    return {"status": "ok", "id": str(result.inserted_id)}
+    message_id = str(result.inserted_id)
+    asyncio.create_task(upsert_message_to_qdrant(message_id))
+    return {"status": "ok", "id": message_id}
 
 @router.get("/messages", dependencies=[Depends(verify_api_key)], tags=["Message"])
 async def list_messages():
@@ -108,7 +112,8 @@ async def fetch_inbox():
             }
 
             result = await db.messages.insert_one(doc)
-            inserted.append(str(result.inserted_id))
+            message_id = str(result.inserted_id)
+            inserted.append(message_id)
 
             # Fetch and store attachments
             att_urls = await _fetch_and_store_attachments(client, headers, m.get("id"))
@@ -116,6 +121,8 @@ async def fetch_inbox():
                 await db.messages.update_one({"_id": result.inserted_id}, {"$set": {"attachments": att_urls}})
 
             await client.post(f"{GRAPH_API_URL}/mail/{m.get('id')}/archive", headers=headers)
+
+            asyncio.create_task(upsert_message_to_qdrant(message_id))
 
     return {"inserted": inserted}
 
@@ -130,6 +137,7 @@ async def update_message(message_id: str, message: Message):
     result = await db.messages.replace_one({"_id": oid}, message.dict())
     if result.matched_count == 0:
         raise HTTPException(status_code=404, detail="Message not found")
+    asyncio.create_task(upsert_message_to_qdrant(message_id))
     return {"status": "aktualisiert"}
 
 
@@ -145,5 +153,26 @@ async def delete_message(message_id: str):
     if result.deleted_count == 0:
         raise HTTPException(status_code=404, detail="Message not found")
     return {"status": "deleted"}
+
+
+@router.get("/messages/{message_id}/similar", dependencies=[Depends(verify_api_key)], tags=["Message"])
+async def get_similar_messages(message_id: str, limit: int = 5):
+    msg = await db.messages.find_one({"_id": ObjectId(message_id)})
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    text = f"{msg.get('subject', '')}\n{msg.get('message', '')}"
+    similar = qdrant_similar_messages(text, message_id, limit)
+    return similar
+
+
+@router.post("/messages/qdrant/reindex", dependencies=[Depends(verify_api_key)], tags=["Qdrant"])
+async def reindex_all_messages():
+    message_ids = await db.messages.distinct("_id")
+    count = 0
+    for mid in message_ids:
+        await upsert_message_to_qdrant(str(mid))
+        count += 1
+    return {"status": "ok", "indexed_messages": count}
 
 

--- a/api/qdrant_utils.py
+++ b/api/qdrant_utils.py
@@ -12,13 +12,20 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 logger = logging.getLogger(__name__)
 qdrant = qdrant_client.QdrantClient(host="localhost", port=6333)
 COLLECTION_NAME = "tasks"
+MESSAGE_COLLECTION_NAME = "messages"
 
 # Init Collection falls nicht vorhanden
-if COLLECTION_NAME not in [c.name for c in qdrant.get_collections().collections]:
+existing = [c.name for c in qdrant.get_collections().collections]
+if COLLECTION_NAME not in existing:
     qdrant.recreate_collection(
-    collection_name=COLLECTION_NAME,
-    vectors_config=VectorParams(size=3072, distance=Distance.COSINE)
-)
+        collection_name=COLLECTION_NAME,
+        vectors_config=VectorParams(size=3072, distance=Distance.COSINE),
+    )
+if MESSAGE_COLLECTION_NAME not in existing:
+    qdrant.recreate_collection(
+        collection_name=MESSAGE_COLLECTION_NAME,
+        vectors_config=VectorParams(size=3072, distance=Distance.COSINE),
+    )
 
 def embed(text: str) -> list[float]:
     """Vektorisiert Text mit OpenAI Embedding."""
@@ -82,6 +89,59 @@ def qdrant_similar_tasks(query_text: str, exclude_id: str, limit: int = 5):
                 "score": hit.score,
                 "task": payload
             })
+        if len(similar) >= limit:
+            break
+    return similar
+
+
+async def upsert_message_to_qdrant(message_id: str):
+    """Lädt eine Nachricht und upsertet sie in Qdrant."""
+    from bson import ObjectId
+    from mongo import db
+
+    msg = await db.messages.find_one({"_id": ObjectId(message_id)})
+    if not msg:
+        logger.warning(f"Message {message_id} nicht gefunden")
+        return
+
+    text = f"{msg.get('subject', '')}\n{msg.get('message', '')}"
+    vector = await asyncio.to_thread(embed, text)
+    payload = {
+        "mongo_id": str(msg["_id"]),
+        "betreff": msg.get("subject"),
+        "absender": msg.get("sender"),
+        "datum": msg.get("datum"),
+        "text": msg.get("message"),
+        "projekt": msg.get("project_id"),
+        "direction": msg.get("direction"),
+    }
+
+    await asyncio.to_thread(
+        qdrant.upsert,
+        collection_name=MESSAGE_COLLECTION_NAME,
+        points=[
+            PointStruct(id=str(uuid4()), vector=vector, payload=payload)
+        ],
+    )
+
+
+def qdrant_similar_messages(query_text: str, exclude_id: str, limit: int = 5):
+    """Sucht ähnliche Nachrichten in Qdrant."""
+    query_vector = embed(query_text)
+    hits = qdrant.search(
+        collection_name=MESSAGE_COLLECTION_NAME,
+        query_vector=query_vector,
+        limit=limit + 10,
+        with_payload=True,
+    )
+
+    similar = []
+    for hit in hits:
+        if hit.score < 0.75:
+            continue
+        payload = hit.payload
+        if payload.get("mongo_id") != exclude_id:
+            similar.append({"score": hit.score, "message": payload})
         if len(similar) >= limit:
             break
     return similar


### PR DESCRIPTION
## Summary
- create a `messages` collection in qdrant on startup
- add functions to upsert and search messages in `qdrant_utils`
- vectorize messages when created, fetched or updated
- expose endpoints to query similar messages and to reindex all messages

## Testing
- `python -m py_compile api/controller/message_controller.py api/qdrant_utils.py`

------
https://chatgpt.com/codex/tasks/task_b_683abe537ba08329b9832c62f589d0d0