### PR TITLE
Add similar tasks search for messages

### DIFF
--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -49,6 +49,24 @@
         </ul>
       </div>
       {% endif %}
+      {% if similar_tasks %}
+      <div class="card mt-3">
+        <div class="card-header">
+          <h6 class="mb-0">Ähnliche Aufgaben</h6>
+        </div>
+        <div class="card-body p-2">
+          <ul class="list-unstyled mb-0">
+            {% for item in similar_tasks %}
+            <li>
+              <a href="/task/view/{{ item.task.mongo_id }}/">{{ item.task.betreff }}</a>
+              {% if item.task.projekt %}<span class="text-muted">({{ item.task.projekt_name }})</span>{% endif %}
+              <small class="text-muted ms-2">Score: {{ item.score|floatformat:2 }}</small>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/otto-ui/core/templates/core/message_editview.html
+++ b/otto-ui/core/templates/core/message_editview.html
@@ -64,6 +64,24 @@
       </div>
     </div>
   </form>
+  {% if similar_tasks %}
+  <div class="card mb-3">
+    <div class="card-header">
+      <h5 class="mb-0">Ähnliche Aufgaben</h5>
+    </div>
+    <div class="card-body p-2">
+      <ul class="list-unstyled mb-0">
+        {% for item in similar_tasks %}
+        <li>
+          <a href="/task/view/{{ item.task.mongo_id }}/">{{ item.task.betreff }}</a>
+          {% if item.task.projekt %}<span class="text-muted">({{ item.task.projekt_name }})</span>{% endif %}
+          <small class="text-muted ms-2">Score: {{ item.score|floatformat:2 }}</small>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% endif %}
   <div id="saveSuccess" class="alert alert-success mt-3 d-none">Gespeichert!</div>
 </div>
 <script src="https://cdn.tiny.cloud/1/kpams0ubmp1xidkpbry2j9afcgmlfpiv96ybkly1llpyi875/tinymce/7/tinymce.min.js" referrerpolicy="origin"></script>

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -79,6 +79,24 @@
           {% endif %}
         </div>
       </div>
+      {% if similar_tasks %}
+      <div class="card mt-3">
+        <div class="card-header">
+          <h6 class="mb-0">Ähnliche Aufgaben</h6>
+        </div>
+        <div class="card-body p-2">
+          <ul class="list-unstyled mb-0">
+            {% for item in similar_tasks %}
+            <li>
+              <a href="/task/view/{{ item.task.mongo_id }}/">{{ item.task.betreff }}</a>
+              {% if item.task.projekt %}<span class="text-muted">({{ item.task.projekt_name }})</span>{% endif %}
+              <small class="text-muted ms-2">Score: {{ item.score|floatformat:2 }}</small>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+      {% endif %}
       {% else %}
       <p class="m-2">Bitte eine Nachricht auswählen.</p>
       {% endif %}


### PR DESCRIPTION
## Summary
- expose new `/messages/{id}/similar_tasks` endpoint
- lower similarity threshold for tasks to 0.7
- show similar tasks in message list, detail, and edit views

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683ac4f592ac8329b5e7bb0e9c75adf2