### PR TITLE
Add message context

### DIFF
--- a/otto-ui/core/templates/core/message_editview.html
+++ b/otto-ui/core/templates/core/message_editview.html
@@ -4,8 +4,10 @@
 <script>
   window.ottoContext = {
     type: "message",
-    name: "{{ message.subject }}",
-    id: "{{ message.id }}"
+    name: "{{ message.subject|escapejs }}",
+    id: "{{ message.id }}",
+    context: "{{ message.message|escapejs }}",
+    gptFunctions: []
   }
 </script>
 <div class="container py-4">

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -1,6 +1,15 @@
 {% extends "base.html" %}
 {% load format_tags %}
 {% block content %}
+<script>
+  window.ottoContext = {
+    type: "message",
+    name: "{{ selected.subject|default:''|escapejs }}",
+    id: "{{ selected.id|default:'' }}",
+    context: "{{ selected.message|default:''|escapejs }}",
+    gptFunctions: []
+  }
+</script>
 <div class="container-fluid">
   <div class="row" style="height: calc(100vh - 120px);">
     <div class="col-4 border-end overflow-auto">

--- a/otto-ui/otto-chat/src/ChatOtto.jsx
+++ b/otto-ui/otto-chat/src/ChatOtto.jsx
@@ -34,9 +34,11 @@ export default function ChatOtto() {
       ? `Verfügbare Funktionen: ${ctxInfo.gptFunctions.join(", ")}.`
       : ""
 
+    const extraContext = ctxInfo?.context ? ` Kontext: ${ctxInfo.context}` : ""
+
     const systemPrompt = {
       role: 'system',
-      content: `Du bist Otto, ein Projekt-KI-Assistent. Wir befinden uns im Kontext ${promptContext}. ${availableFunctions}`
+      content: `Du bist Otto, ein Projekt-KI-Assistent. Wir befinden uns im Kontext ${promptContext}.${extraContext ? extraContext : ''} ${availableFunctions}`
     }
 
     const saved = localStorage.getItem('ottoChatMessages_' + context)
@@ -58,9 +60,11 @@ export default function ChatOtto() {
       ? `${ctxInfo.type} „${ctxInfo.name}“ (ID: ${ctxInfo.id}) - Funktionen: ${ctxInfo.gptFunctions.join(", ")}`
       : context
 
+    const extraContext = ctxInfo?.context ? ` Kontext: ${ctxInfo.context}` : ""
+
     const systemPrompt = {
       role: 'system',
-      content: `Du bist Otto, ein Projekt-KI-Assistent. Gib strukturierte, klare Antworten in HTML oder Tabellenform. Nutze Listen und Zwischenüberschriften. Wir befinden uns im Kontext ${promptContext}.`
+      content: `Du bist Otto, ein Projekt-KI-Assistent. Gib strukturierte, klare Antworten in HTML oder Tabellenform. Nutze Listen und Zwischenüberschriften. Wir befinden uns im Kontext ${promptContext}.${extraContext ? extraContext : ''}`
     }
 
     const userContent = selectedFunction


### PR DESCRIPTION
## Summary
- expand ottoContext with `context` for message pages
- read new context field in ChatOtto

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_683afcac338083299e312ba8fe9f086d