### PR TITLE
Fix missing view export for message project updates

### DIFF
--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -27,6 +27,7 @@ from .messages import (
     message_create,
     fetch_messages,
     delete_message,
+    update_message_project,
 )
 from .sprints import (
     sprint_listview,


### PR DESCRIPTION
## Summary
- export `update_message_project` in `core.views.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b08fea56483299ff45a338f900110