### PR TITLE
Implement task comment functionality

### DIFF
--- a/api/controller/comment_controller.py
+++ b/api/controller/comment_controller.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+from datetime import datetime
+from bson import ObjectId
+
+from model.comment import Comment
+from mongo import db, comments_collection, personen_collection, messages_collection
+from helper import verify_api_key, serialize_mongo
+from model.message import Message
+
+router = APIRouter()
+
+@router.get("/tasks/{task_id}/comments", dependencies=[Depends(verify_api_key)], tags=["Task"])
+async def list_comments(task_id: str) -> List[Comment]:
+    cursor = comments_collection.find({"task_id": task_id}).sort("datum", 1)
+    return [serialize_mongo(c) async for c in cursor]
+
+@router.post("/tasks/{task_id}/comments", dependencies=[Depends(verify_api_key)], tags=["Task"])
+async def create_comment(task_id: str, comment: Comment, send_email: bool = False):
+    comment_dict = comment.dict()
+    comment_dict["task_id"] = task_id
+    if comment_dict.get("datum") is None:
+        comment_dict["datum"] = datetime.utcnow()
+
+    # Optionally send an email to the requester and store as message
+    message_id = None
+    if send_email:
+        task = await db.tasks.find_one({"_id": ObjectId(task_id)})
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+        requester_id = task.get("requester_id")
+        if not requester_id:
+            raise HTTPException(status_code=400, detail="Task has no requester")
+        requester = await personen_collection.find_one({"_id": ObjectId(requester_id)})
+        if not requester:
+            raise HTTPException(status_code=404, detail="Requester not found")
+        mail = Message(
+            datum=datetime.utcnow(),
+            subject=task.get("betreff", "Task"),
+            sender=None,
+            to=[requester.get("email")],
+            cc=None,
+            message=comment_dict.get("text"),
+            direction="out",
+            status="gesendet",
+            project_id=task.get("project_id"),
+            task_id=task_id,
+        )
+        msg_result = await messages_collection.insert_one(mail.dict())
+        message_id = str(msg_result.inserted_id)
+        comment_dict["type"] = "email_out"
+        comment_dict["message_id"] = message_id
+
+    result = await comments_collection.insert_one(comment_dict)
+    return {"status": "ok", "id": str(result.inserted_id), "message_id": message_id}

--- a/api/main.py
+++ b/api/main.py
@@ -88,6 +88,12 @@ except Exception as e:
     print(f"⚠️ Fehler beim Einbinden von message_controller: {e}")
 
 try:
+    from controller.comment_controller import router as comment_router
+    app.include_router(comment_router)
+except Exception as e:
+    print(f"⚠️ Fehler beim Einbinden von comment_controller: {e}")
+
+try:
     from controller.sprint_controller import router as sprint_router
     app.include_router(sprint_router)
 except Exception as e:

--- a/api/model/comment.py
+++ b/api/model/comment.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import Optional, Literal
+from datetime import datetime
+
+class Comment(BaseModel):
+    """Eine zeitgestempelte Notiz oder E-Mail zu einer Aufgabe."""
+
+    datum: datetime
+    task_id: str
+    user_id: str
+    text: str
+    type: Literal["note", "email_in", "email_out"] = "note"
+    message_id: Optional[str] = None

--- a/api/mongo.py
+++ b/api/mongo.py
@@ -17,6 +17,7 @@ sprints_collection = db.sprints
 teams_collection = db.teams
 users = db["users"]
 messages_collection = db.messages
+comments_collection = db.comments
 db.meetings.delete_many({"id": ""})
 
 def get_tagesplan_collection() -> Collection:


### PR DESCRIPTION
## Summary
- add `Comment` model for timestamped notes and emails
- create comment API controller with optional email sending via messages
- register `comment_controller` in API
- add Mongo collection for comments

## Testing
- `python -m py_compile api/model/comment.py api/controller/comment_controller.py`
- `python -m py_compile api/main.py api/mongo.py`
- `find api -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_b_683b08798e50832990b319b7be6f4e51