### PR TITLE
Implement message archiving

### DIFF
--- a/api/model/message.py
+++ b/api/model/message.py
@@ -15,7 +15,7 @@ class Message(BaseModel):
     cc: Optional[List[EmailStr]] = None
     message: str  # HTML Inhalt
     direction: Literal["in", "out"]
-    status: Literal["gesendet", "neu", "fehler"] = "neu"
+    status: Literal["gesendet", "neu", "fehler", "archiviert"] = "neu"
     project_id: Optional[str] = None
     task_id: Optional[str] = None
     sprint_id: Optional[str] = None

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -42,6 +42,11 @@ urlpatterns = [
         views.update_message_project,
         name="update_message_project",
     ),
+    path(
+        "message/update_status/",
+        views.update_message_status,
+        name="update_message_status",
+    ),
     path("message/<str:message_id>/", views.message_detailview, name="message_detail"),
     path("sprint/", views.sprint_listview, name="sprint_liste"),
     path("sprint/new/", views.sprint_create, name="sprint_create"),

--- a/otto-ui/core/templates/core/message_detailview.html
+++ b/otto-ui/core/templates/core/message_detailview.html
@@ -8,6 +8,14 @@
       <input type="hidden" name="message_id" value="{{ message.id }}">
       <button type="submit" class="btn btn-outline-primary" {% if message.direction != 'out' or message.status == 'gesendet' %}disabled{% endif %}>📧 Senden</button>
     </form>
+    {% if message.direction == 'in' and message.status != 'archiviert' %}
+    <form method="post" action="/message/update_status/" class="btn-group ms-2" role="group">
+      {% csrf_token %}
+      <input type="hidden" name="message_id" value="{{ message.id }}">
+      <input type="hidden" name="status" value="archiviert">
+      <button type="submit" class="btn btn-outline-secondary">🗄️ Archivieren</button>
+    </form>
+    {% endif %}
   </div>
   <div class="card">
     <div class="card-header">

--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -16,6 +16,7 @@
       <ul class="nav nav-pills mb-3">
         <li class="nav-item"><a class="nav-link {% if folder == 'in' %}active{% endif %}" href="?folder=in">Posteingang</a></li>
         <li class="nav-item"><a class="nav-link {% if folder == 'out' %}active{% endif %}" href="?folder=out">Gesendet</a></li>
+        <li class="nav-item"><a class="nav-link {% if folder == 'archiv' %}active{% endif %}" href="?folder=archiv">Archiviert</a></li>
       </ul>
       <div class="list-group">
         {% for m in messages %}
@@ -26,13 +27,23 @@
             <small>{{ m.datum|slice:":10" }}</small>
           </div>
           <small class="pe-4">{{ m.to|join:', ' }}</small>
+          {% if m.direction == 'in' and m.status != 'archiviert' %}
+          <a
+            hx-post="/message/update_status/"
+            hx-vals='{"message_id": "{{ m.id }}", "status": "archiviert"}'
+            hx-target="closest .message-item"
+            hx-swap="outerHTML"
+            class="position-absolute bottom-0 end-0 m-1 text-decoration-none"
+            style="font-size: 12px; width: 12px; height: 12px; display: inline-block; z-index: 2;"
+            >🗄️</a>
+          {% endif %}
           <a
             hx-post="/message/delete/"
             hx-vals='{"message_id": "{{ m.id }}"}'
             hx-confirm="Wirklich löschen?"
             hx-target="closest .message-item"
             hx-swap="outerHTML"
-            class="position-absolute bottom-0 end-0 m-1 text-danger text-decoration-none"
+            class="position-absolute bottom-0 end-0 me-4 m-1 text-danger text-decoration-none"
             style="font-size: 12px; width: 12px; height: 12px; display: inline-block; z-index: 2;"
             >❌</a>
         </div>
@@ -53,6 +64,14 @@
           <input type="hidden" name="message_id" value="{{ selected.id }}">
           <button type="submit" class="btn btn-outline-primary" {% if selected.direction != 'out' or selected.status == 'gesendet' %}disabled{% endif %}>📧 Senden</button>
         </form>
+        {% if selected.direction == 'in' and selected.status != 'archiviert' %}
+        <form method="post" action="/message/update_status/" class="btn-group ms-2" role="group">
+          {% csrf_token %}
+          <input type="hidden" name="message_id" value="{{ selected.id }}">
+          <input type="hidden" name="status" value="archiviert">
+          <button type="submit" class="btn btn-outline-secondary">🗄️ Archivieren</button>
+        </form>
+        {% endif %}
         {% endif %}
       </div>
       {% if selected %}

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -28,6 +28,7 @@ from .messages import (
     fetch_messages,
     delete_message,
     update_message_project,
+    update_message_status,
 )
 from .sprints import (
     sprint_listview,

--- a/otto-ui/core/views/messages.py
+++ b/otto-ui/core/views/messages.py
@@ -29,9 +29,20 @@ def message_listview(request):
     )
     projekte = proj_res.json() if proj_res.status_code == 200 else []
 
-    messages = [
-        m for m in msgs if m.get("direction") == ("in" if folder == "in" else "out")
-    ]
+    if folder == "archiv":
+        messages = [
+            m
+            for m in msgs
+            if m.get("direction") == "in" and m.get("status") == "archiviert"
+        ]
+    elif folder == "in":
+        messages = [
+            m
+            for m in msgs
+            if m.get("direction") == "in" and m.get("status") != "archiviert"
+        ]
+    else:
+        messages = [m for m in msgs if m.get("direction") == "out"]
 
     for m in messages:
         try:
@@ -330,6 +341,37 @@ def update_message_project(request):
             else JsonResponse({"error": "Fehler beim Speichern."}, status=500)
         )
 
+    return JsonResponse({"error": "Ungültige Methode."}, status=405)
+
+
+@login_required
+@csrf_exempt
+def update_message_status(request):
+    if request.method == "POST":
+        message_id = request.POST.get("message_id")
+        new_status = request.POST.get("status")
+        if not message_id:
+            return JsonResponse({"error": "Keine Message-ID."}, status=400)
+
+        res = requests.get(
+            f"{OTTO_API_URL}/messages/{message_id}",
+            headers={"x-api-key": OTTO_API_KEY},
+        )
+        if res.status_code != 200:
+            return JsonResponse({"error": "Nachricht nicht gefunden."}, status=404)
+
+        message = res.json()
+        message["status"] = new_status
+        update = requests.put(
+            f"{OTTO_API_URL}/messages/{message_id}",
+            headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+            data=json.dumps(message),
+        )
+        if update.status_code == 200:
+            if request.headers.get("HX-Request") == "true":
+                return HttpResponse("")
+            return redirect(request.META.get("HTTP_REFERER", "/message/"))
+        return JsonResponse({"error": "Fehler beim Speichern."}, status=500)
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
 
 


### PR DESCRIPTION
## Summary
- introduce new `archiviert` status in message model
- allow filtering archived messages in list view
- add archive button and toolbar actions
- expose endpoint to update message status

## Testing
- `python -m py_compile api/model/message.py otto-ui/core/views/messages.py otto-ui/core/views/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b0c8280b483299e807e7f6870ce09