### PR TITLE
Enable AI to open prefilled project form

### DIFF
--- a/otto-ai/function_call_templates/projekt/open_project_form.json
+++ b/otto-ai/function_call_templates/projekt/open_project_form.json
@@ -1,0 +1,17 @@
+{
+  "type": "function",
+  "function": {
+    "name": "open_project_form",
+    "description": "Öffnet im Otto-Frontend ein Formular zur Projekterstellung mit vorausgefüllten Feldern.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string", "description": "Projektname"},
+        "short": {"type": "string", "description": "Kurzbezeichnung"},
+        "beschreibung": {"type": "string", "description": "Projektbeschreibung"},
+        "status": {"type": "string", "description": "Projektstatus"},
+        "prio": {"type": "string", "description": "Projektpriorität"}
+      }
+    }
+  }
+}

--- a/otto-ai/main.py
+++ b/otto-ai/main.py
@@ -89,6 +89,8 @@ async def chat(request: ChatRequest):
 
 
 async def call_function_and_respond(name, args, messages, tool_call):
+    if name == "open_project_form":
+        return {"reply": "Projektformular wird geöffnet", "action": "open_project_form", "values": args}
     if name == "get_project_by_id":
         url = f"{OTTO_API_URL}context/projekt/{args.get('project_id')}"
     elif name == "get_task_by_id":

--- a/otto-ui/core/function_call_templates/projekt/open_project_form.json
+++ b/otto-ui/core/function_call_templates/projekt/open_project_form.json
@@ -1,0 +1,17 @@
+{
+  "type": "function",
+  "function": {
+    "name": "open_project_form",
+    "description": "Öffnet im Otto-Frontend ein Formular zur Projekterstellung mit vorausgefüllten Feldern.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string", "description": "Projektname"},
+        "short": {"type": "string", "description": "Kurzbezeichnung"},
+        "beschreibung": {"type": "string", "description": "Projektbeschreibung"},
+        "status": {"type": "string", "description": "Projektstatus"},
+        "prio": {"type": "string", "description": "Projektpriorität"}
+      }
+    }
+  }
+}

--- a/otto-ui/core/static/otto_extension.js
+++ b/otto-ui/core/static/otto_extension.js
@@ -1,0 +1,9 @@
+window.ottoUI = window.ottoUI || {};
+window.ottoUI.openProjectForm = function(values) {
+  try {
+    var params = new URLSearchParams(values || {}).toString();
+    window.location.href = '/project/new/' + (params ? ('?' + params) : '');
+  } catch (e) {
+    console.error('openProjectForm failed', e);
+  }
+};

--- a/otto-ui/core/templates/base.html
+++ b/otto-ui/core/templates/base.html
@@ -149,6 +149,7 @@
             }
         });
     </script>
-    <script type="module" src="{% static 'otto_chat/assets/index-CHXh8mMx.js' %}"></script>            
+    <script type="module" src="{% static 'otto_chat/assets/index-CHXh8mMx.js' %}"></script>
+    <script src="{% static 'otto_extension.js' %}"></script>
 </body>
 </html>

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -74,11 +74,18 @@ def project_create(request):
             return JsonResponse({"error": str(e)}, status=400)
 
     personen, agenten = load_person_lists()
+    initial = {
+        "name": request.GET.get("name", ""),
+        "short": request.GET.get("short", ""),
+        "beschreibung": request.GET.get("beschreibung", ""),
+        "status": request.GET.get("status", ""),
+        "prio": request.GET.get("prio", "")
+    }
     return render(
         request,
         "core/project_detailview.html",
         {
-            "projekt": {},
+            "projekt": initial,
             "personen": personen,
             "agenten": agenten,
             "tasks": [],

--- a/otto-ui/otto-chat/src/ChatOtto.jsx
+++ b/otto-ui/otto-chat/src/ChatOtto.jsx
@@ -89,6 +89,9 @@ export default function ChatOtto() {
         body: JSON.stringify({ messages: fullMessages })
       })
       const data = await res.json()
+      if (data.action === 'open_project_form' && window.ottoUI?.openProjectForm) {
+        window.ottoUI.openProjectForm(data.values || {})
+      }
       setMessages([...messages, { role: 'user', content: input }, { role: 'assistant', content: data.reply }])
     } catch {
       setMessages([...messages, { role: 'user', content: input }, { role: 'assistant', content: 'Fehler bei der Kommunikation mit Otto.' }])


### PR DESCRIPTION
## Summary
- add `open_project_form` function template for AI and UI
- call UI helper from chat to open prefilled form
- prefill project form via query parameters
- expose `openProjectForm` in `otto_extension.js`
- remove compiled bundle from version control

## Testing
- `python -m py_compile otto-ai/main.py otto-ui/core/views/projects.py`
- `python -m compileall -q otto-ai/main.py otto-ui/core/views/projects.py`


------
https://chatgpt.com/codex/tasks/task_b_683b0a6afe608329a8281d71043e645f