### PR TITLE
Add TinyMCE editor to project description

### DIFF
--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -47,7 +47,7 @@
                     </div>
                     <div class="mb-3">
                         <label class="form-label">Beschreibung</label>
-                        <textarea name="beschreibung" class="form-control">{{ projekt.beschreibung }}</textarea>
+                        <textarea id="editor" name="beschreibung" class="form-control">{{ projekt.beschreibung|safe }}</textarea>
                     </div>
                     <div class="mb-4">
                         <label class="form-label">Stakeholder</label>
@@ -94,8 +94,19 @@
     </div>
   <div id="saveSuccess" class="alert alert-success mt-3 d-none">Gespeichert!</div>
 
-   
+
   </form>
+
+  <script src="https://cdn.tiny.cloud/1/kpams0ubmp1xidkpbry2j9afcgmlfpiv96ybkly1llpyi875/tinymce/7/tinymce.min.js" referrerpolicy="origin"></script>
+  <script>
+    tinymce.init({
+      selector: '#editor',
+      plugins: 'lists advlist link image table code charmap autolink codesample link searchreplace fullscreen emoticons',
+      toolbar: 'link | undo redo | bold italic | alignleft aligncenter alignright | code codesample searchreplace fullscreen emoticons',
+      license_key: 'gpl',
+      height: 300
+    });
+  </script>
 
   <hr class="my-4">
 
@@ -324,6 +335,9 @@
   form.appendChild(errorBox);
 
   function collectFormData() {
+    if (window.tinymce) {
+      tinymce.triggerSave();
+    }
     const formData = new FormData(form);
     const jsonData = {};
     formData.forEach((value, key) => {


### PR DESCRIPTION
## Summary
- enhance project detail view by using TinyMCE for the description
- ensure HTML content is captured when saving

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683b112187548329825a25a8c5d77cbe