### PR TITLE
Fix encoding issues when opening project form

### DIFF
--- a/otto-ui/core/static/otto_extension.js
+++ b/otto-ui/core/static/otto_extension.js
@@ -1,7 +1,12 @@
 window.ottoUI = window.ottoUI || {};
 window.ottoUI.openProjectForm = function(values) {
   try {
-    var params = new URLSearchParams(values || {}).toString();
+    var params = Object.keys(values || {})
+      .map(function(key) {
+        var v = values[key];
+        return encodeURIComponent(key) + "=" + encodeURIComponent(v);
+      })
+      .join("&");
     window.location.href = '/project/new/' + (params ? ('?' + params) : '');
   } catch (e) {
     console.error('openProjectForm failed', e);


### PR DESCRIPTION
## Summary
- ensure project form parameters are properly escaped when building URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b13aed28c8329890bd8b003869c88