### PR TITLE
Add completed tasks filter

### DIFF
--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -135,6 +135,12 @@
         {% endfor %}
       </select>
     </div>
+    <div class="col-sm-3">
+      <div class="form-check mt-1">
+        <input type="checkbox" class="form-check-input" id="showDone" name="show_done" value="1" {% if show_done %}checked{% endif %} onchange="this.form.submit()">
+        <label class="form-check-label" for="showDone">Abgeschlossene anzeigen</label>
+      </div>
+    </div>
     <div class="col-auto">
       <button type="submit" class="btn btn-outline-primary">Suchen</button>
       {% if task_q or sprint_id %}
@@ -210,15 +216,15 @@
     <nav aria-label="Seiten" class="mt-3">
       <ul class="pagination justify-content-center">
         <li class="page-item {% if task_page <= 1 %}disabled{% endif %}">
-          <a class="page-link" href="?task_q={{ task_q }}{% if sprint_id %}&sprint_id={{ sprint_id }}{% endif %}&task_page={{ task_page|add:-1 }}">Vorherige</a>
+          <a class="page-link" href="?task_q={{ task_q }}{% if sprint_id %}&sprint_id={{ sprint_id }}{% endif %}{% if show_done %}&show_done=1{% endif %}&task_page={{ task_page|add:-1 }}">Vorherige</a>
         </li>
         {% for p in task_page_numbers %}
         <li class="page-item {% if p == task_page %}active{% endif %}">
-          <a class="page-link" href="?task_q={{ task_q }}{% if sprint_id %}&sprint_id={{ sprint_id }}{% endif %}&task_page={{ p }}">{{ p }}</a>
+          <a class="page-link" href="?task_q={{ task_q }}{% if sprint_id %}&sprint_id={{ sprint_id }}{% endif %}{% if show_done %}&show_done=1{% endif %}&task_page={{ p }}">{{ p }}</a>
         </li>
         {% endfor %}
         <li class="page-item {% if task_page >= task_total_pages %}disabled{% endif %}">
-          <a class="page-link" href="?task_q={{ task_q }}{% if sprint_id %}&sprint_id={{ sprint_id }}{% endif %}&task_page={{ task_page|add:1 }}">Nächste</a>
+          <a class="page-link" href="?task_q={{ task_q }}{% if sprint_id %}&sprint_id={{ sprint_id }}{% endif %}{% if show_done %}&show_done=1{% endif %}&task_page={{ task_page|add:1 }}">Nächste</a>
         </li>
       </ul>
     </nav>

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -146,6 +146,7 @@ def project_detailview(request, project_id):
 
     task_q = request.GET.get("task_q", "").lower()
     sprint_id_filter = request.GET.get("sprint_id")
+    show_done = request.GET.get("show_done")
     try:
         task_page = int(request.GET.get("task_page", 1))
     except ValueError:
@@ -154,6 +155,12 @@ def project_detailview(request, project_id):
 
     filtered_tasks = []
     for t in tasks:
+        if show_done:
+            if t.get("status") != "✅ abgeschlossen":
+                continue
+        else:
+            if t.get("status") == "✅ abgeschlossen":
+                continue
         if task_q:
             if (
                 task_q not in t.get("betreff", "").lower()
@@ -208,6 +215,7 @@ def project_detailview(request, project_id):
             "task_total_pages": task_total_pages,
             "task_page_numbers": task_page_numbers,
             "task_q": task_q,
+            "show_done": bool(show_done),
             "email_templates": email_templates,
         },
     )


### PR DESCRIPTION
## Summary
- filter project tasks by completion status using `show_done` query parameter
- add checkbox in project detail view to toggle completed tasks
- preserve filter state during pagination

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b6e1b2df48329ad3f61ec68df3cdd