### PR TITLE
Add comments view for tasks

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path("task/delete/", views.delete_task, name="delete_task"),
     path("task/update/", views.update_task_details, name="update_task_details"),
     path("task/new/", views.task_create, name="task_create"),
+    path("task/add_comment/", views.add_task_comment, name="task_add_comment"),
     path("task/view/<str:task_id>/", views.task_pageview, name="task_pageview"),
     path("person/", views.person_listview, name="person_liste"),
     path("person/new/", views.person_create, name="person_create"),

--- a/otto-ui/core/templates/components/comment_item.html
+++ b/otto-ui/core/templates/components/comment_item.html
@@ -1,0 +1,13 @@
+<div class="border rounded p-2 mb-2">
+  <div class="small text-muted">
+    <strong>{{ person_name }}</strong>
+    <span class="ms-1">{{ c.datum|slice:":16" }}</span>
+    {% if c.type != 'note' %}
+      <span class="badge bg-secondary ms-1">{{ c.type }}</span>
+    {% endif %}
+    {% if c.message_id %}
+      <a href="/message/{{ c.message_id }}/" class="ms-1">📧</a>
+    {% endif %}
+  </div>
+  <div>{{ c.text|linebreaksbr }}</div>
+</div>

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load format_tags %}
 {% block content %}
 <script>
   window.ottoContext = {
@@ -148,6 +149,32 @@
     </div>
   </div>
   {% endif %}
+  <div class="card mb-3">
+    <div class="card-header">
+      <h5 class="mb-0">Kommentare</h5>
+    </div>
+    <div class="card-body">
+      <div id="commentsList">
+        {% for c in comments %}
+          {% with person_name=personen_map|get_item:c.user_id %}
+            {% include 'components/comment_item.html' with c=c person_name=person_name %}
+          {% endwith %}
+        {% empty %}
+        <p class="text-muted">Keine Kommentare vorhanden.</p>
+        {% endfor %}
+      </div>
+      <form id="commentForm" class="mt-3">
+        {% csrf_token %}
+        <input type="hidden" name="task_id" value="{{ task.id }}">
+        <textarea class="form-control mb-2" name="text" rows="2" placeholder="Kommentar..."></textarea>
+        <div class="form-check mb-2">
+          <input class="form-check-input" type="checkbox" value="1" id="sendEmail" name="send_email">
+          <label class="form-check-label" for="sendEmail">Als E-Mail an Requester senden</label>
+        </div>
+        <button type="submit" class="btn btn-outline-primary">Hinzufügen</button>
+      </form>
+    </div>
+  </div>
   {{ sprints|json_script:"sprints-data" }}
 </div>
 <script>
@@ -263,6 +290,28 @@ document.getElementById('deleteBtn').addEventListener('click', () => {
       }
     });
   }
+});
+
+const commentForm = document.getElementById('commentForm');
+commentForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const formData = new FormData(commentForm);
+  fetch('/task/add_comment/', {
+    method: 'POST',
+    headers: {
+      'X-CSRFToken': getCookie('csrftoken')
+    },
+    body: formData
+  }).then(r => r.ok ? r.json() : Promise.reject()).then(d => {
+    if(d.success && d.html){
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = d.html;
+      document.getElementById('commentsList').appendChild(wrapper.firstElementChild);
+      commentForm.reset();
+    } else if(d.error){
+      alert(d.error);
+    }
+  }).catch(()=>alert('Fehler beim Speichern des Kommentars'));
 });
 </script>
 {% endblock %}

--- a/otto-ui/core/templatetags/format_tags.py
+++ b/otto-ui/core/templatetags/format_tags.py
@@ -32,3 +32,11 @@ def basename(value: str):
         return unquote(name) or value
     except Exception:
         return value
+
+
+@register.filter
+def get_item(mapping, key):
+    try:
+        return mapping.get(key, '')
+    except Exception:
+        return ''

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -10,6 +10,7 @@ from .tasks import (
     delete_task,
     task_create,
     task_pageview,
+    add_task_comment,
 )
 from .projects import (
     project_listview,

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse, HttpResponse
 from django.shortcuts import render, redirect
 from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
+from django.template.loader import render_to_string
 from core.const import prio_liste, status_liste, typ_liste
 import os
 from dotenv import load_dotenv
@@ -481,6 +482,12 @@ def task_pageview(request, task_id):
         headers={"x-api-key": OTTO_API_KEY},
     )
     similar_tasks = similar_res.json() if similar_res.status_code == 200 else []
+    comments_res = requests.get(
+        f"{OTTO_API_URL}/tasks/{task_id}/comments",
+        headers={"x-api-key": OTTO_API_KEY},
+    )
+    comments = comments_res.json() if comments_res.status_code == 200 else []
+    personen_map = {p.get("id"): p.get("name") for p in personen}
     return render(request, "core/task_detailpage.html", {
         "task": task,
         "personen": personen,
@@ -492,4 +499,45 @@ def task_pageview(request, task_id):
         "typ_liste": typ_liste,
         "sprints": sprints,
         "similar_tasks": similar_tasks,
+        "comments": comments,
+        "personen_map": personen_map,
     })
+
+
+@login_required
+@csrf_exempt
+def add_task_comment(request):
+    if request.method == "POST":
+        task_id = request.POST.get("task_id")
+        text = request.POST.get("text", "").strip()
+        send_email = request.POST.get("send_email") == "1"
+        user = request.session.get("user", {})
+        user_id = user.get("id")
+
+        if not task_id or not text:
+            return JsonResponse({"error": "Ungültige Daten."}, status=400)
+
+        payload = {
+            "datum": datetime.utcnow().isoformat(),
+            "task_id": task_id,
+            "user_id": user_id,
+            "text": text,
+            "type": "note",
+        }
+
+        res = requests.post(
+            f"{OTTO_API_URL}/tasks/{task_id}/comments?send_email={'true' if send_email else 'false'}",
+            headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+            data=json.dumps(payload),
+        )
+
+        if res.status_code in (200, 201):
+            person_name = user.get("name", "")
+            html = render_to_string(
+                "components/comment_item.html",
+                {"c": payload, "person_name": person_name},
+            )
+            return JsonResponse({"success": True, "html": html})
+        return JsonResponse({"error": "Fehler beim Speichern."}, status=500)
+
+    return JsonResponse({"error": "Ungültige Methode."}, status=405)


### PR DESCRIPTION
## Summary
- show comments on task detail page
- allow adding new comments with optional email
- expose new endpoint in Django UI to add comments
- include helper filter to access dict items

## Testing
- `python -m py_compile otto-ui/core/views/tasks.py otto-ui/core/templatetags/format_tags.py`


------
https://chatgpt.com/codex/tasks/task_b_683b6d7f3e58832981b42977fdb5ffcf