### PR TITLE
Add open_task_form handler without compiled js changes

### DIFF
--- a/otto-ai/function_call_templates/projekt/open_task_form.json
+++ b/otto-ai/function_call_templates/projekt/open_task_form.json
@@ -1,0 +1,17 @@
+{
+  "type": "function",
+  "function": {
+    "name": "open_task_form",
+    "description": "Öffnet im Otto-Frontend ein Formular zur Aufgabenerstellung mit vorausgefüllten Feldern. Das Projekt wird aus dem aktuellen Kontext entnommen.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "betreff": {"type": "string", "description": "Titel der Aufgabe"},
+        "beschreibung": {"type": "string", "description": "Aufgabenbeschreibung"},
+        "status": {"type": "string", "description": "Status der Aufgabe"},
+        "prio": {"type": "string", "description": "Priorität der Aufgabe"},
+        "termin": {"type": "string", "description": "Fälligkeitsdatum im ISO-Format"}
+      }
+    }
+  }
+}

--- a/otto-ai/main.py
+++ b/otto-ai/main.py
@@ -91,6 +91,8 @@ async def chat(request: ChatRequest):
 async def call_function_and_respond(name, args, messages, tool_call):
     if name == "open_project_form":
         return {"reply": "Projektformular wird geöffnet", "action": "open_project_form", "values": args}
+    if name == "open_task_form":
+        return {"reply": "Taskformular wird geöffnet", "action": "open_task_form", "values": args}
     if name == "get_project_by_id":
         url = f"{OTTO_API_URL}context/projekt/{args.get('project_id')}"
     elif name == "get_task_by_id":

--- a/otto-ui/core/static/otto_extension.js
+++ b/otto-ui/core/static/otto_extension.js
@@ -12,3 +12,15 @@ window.ottoUI.openProjectForm = function(values) {
     console.error('openProjectForm failed', e);
   }
 };
+
+window.ottoUI.openTaskForm = function(values) {
+  try {
+    var params = new URLSearchParams(values || {});
+    if (window.ottoContext && window.ottoContext.id) {
+      params.set('project_id', window.ottoContext.id);
+    }
+    window.location.href = '/task/new/' + (params.toString() ? ('?' + params.toString()) : '');
+  } catch (e) {
+    console.error('openTaskForm failed', e);
+  }
+};

--- a/otto-ui/otto-chat/src/ChatOtto.jsx
+++ b/otto-ui/otto-chat/src/ChatOtto.jsx
@@ -91,6 +91,8 @@ export default function ChatOtto() {
       const data = await res.json()
       if (data.action === 'open_project_form' && window.ottoUI?.openProjectForm) {
         window.ottoUI.openProjectForm(data.values || {})
+      } else if (data.action === 'open_task_form' && window.ottoUI?.openTaskForm) {
+        window.ottoUI.openTaskForm(data.values || {})
       }
       setMessages([...messages, { role: 'user', content: input }, { role: 'assistant', content: data.reply }])
     } catch {


### PR DESCRIPTION
## Summary
- enable backend action `open_task_form`
- provide project-scoped function template for task form
- expose `openTaskForm` in the extension script
- trigger task form from ChatOtto.jsx
- revert compiled chat asset to avoid direct edits

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_683b6d35e4208329b26c899639c4dd9c