### PR TITLE
Fix comment form missing task_id

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -163,7 +163,7 @@
         <p class="text-muted">Keine Kommentare vorhanden.</p>
         {% endfor %}
       </div>
-      <form id="commentForm" class="mt-3">
+      <form id="commentForm" class="mt-3" data-task-id="{{ task.id }}">
         {% csrf_token %}
         <input type="hidden" name="task_id" value="{{ task.id }}">
         <textarea class="form-control mb-2" name="text" rows="2" placeholder="Kommentar..."></textarea>
@@ -293,9 +293,11 @@ document.getElementById('deleteBtn').addEventListener('click', () => {
 });
 
 const commentForm = document.getElementById('commentForm');
+const commentTaskId = commentForm.dataset.taskId;
 commentForm.addEventListener('submit', e => {
   e.preventDefault();
   const formData = new FormData(commentForm);
+  if(!formData.get('task_id')) formData.set('task_id', commentTaskId);
   fetch('/task/add_comment/', {
     method: 'POST',
     headers: {
@@ -308,6 +310,7 @@ commentForm.addEventListener('submit', e => {
       wrapper.innerHTML = d.html;
       document.getElementById('commentsList').appendChild(wrapper.firstElementChild);
       commentForm.reset();
+      commentForm.elements['task_id'].value = commentTaskId;
     } else if(d.error){
       alert(d.error);
     }


### PR DESCRIPTION
## Summary
- keep task_id stable in comment form and JavaScript

## Testing
- `python check_chroma.py` *(fails: numpy float type issue)*

------
https://chatgpt.com/codex/tasks/task_b_683b7505a9348329bddae10393cb90ee