### PR TITLE
Add context field on task detail page

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -6,6 +6,7 @@
     type: "task",
     name: "{{ task.betreff }}",
     id: "{{ task.id }}",
+    context: {{ context_json|safe }},
     gptFunctions: ["get_task_by_id"]
   }
 </script>

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -478,6 +478,11 @@ def task_pageview(request, task_id):
     sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = meetings_res.json() if meetings_res.status_code == 200 else []
+    context_res = requests.get(
+        f"{OTTO_API_URL}/context/aufgabe/{task_id}",
+        headers={"x-api-key": OTTO_API_KEY},
+    )
+    task_context = context_res.json() if context_res.status_code == 200 else {}
     similar_res = requests.get(
         f"{OTTO_API_URL}/tasks/{task_id}/similar",
         headers={"x-api-key": OTTO_API_KEY},
@@ -502,6 +507,7 @@ def task_pageview(request, task_id):
         "similar_tasks": similar_tasks,
         "comments": comments,
         "personen_map": personen_map,
+        "context_json": json.dumps(task_context),
     })
 
 


### PR DESCRIPTION
## Summary
- fetch context from `/context/aufgabe/{task_id}` in task_pageview
- expose returned JSON via `context_json` to the template
- inject `context` field into `window.ottoContext` on task detail page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683bff33acb48329ba36dc9a352f6372