### PR TITLE
Add comments to task context endpoint

### DIFF
--- a/api/controller/context_controller.py
+++ b/api/controller/context_controller.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException
 from bson import ObjectId
 from helper import verify_api_key, serialize_mongo
-from mongo import projekte_collection, personen_collection, sprints_collection, db
+from mongo import (
+    projekte_collection,
+    personen_collection,
+    sprints_collection,
+    comments_collection,
+    db,
+)
 
 router = APIRouter()
 
@@ -142,6 +148,9 @@ async def aufgabe_context(aufgabe_id: str):
         if sprint:
             task_dict["sprint"] = serialize_mongo(sprint)
 
+    # Kommentare zur Aufgabe laden
+    comments_cursor = comments_collection.find({"task_id": aufgabe_id}).sort("datum", 1)
+    task_dict["comments"] = [serialize_mongo(c) async for c in comments_cursor]
 
     return task_dict
 


### PR DESCRIPTION
## Summary
- import comments collection in context controller
- include sorted comments in `/context/aufgabe/{id}` response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c010b6a2c8329a67c696f6b4d71ee