### PR TITLE
Implement description improvement using AI

### DIFF
--- a/api/controller/ai_controller.py
+++ b/api/controller/ai_controller.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException, Body
+from openai import OpenAI
+import os
+import logging
+from helper import verify_api_key
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+@router.post("/ai/improve_description", dependencies=[Depends(verify_api_key)], tags=["AI"])
+async def improve_description(text: str = Body(..., embed=True)):
+    """Verbessert einen deutschen Text grammatikalisch ohne neue Inhalte zu erfinden."""
+    if not text:
+        raise HTTPException(status_code=400, detail="Text fehlt")
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "Du korrigierst deutschen Text. "
+                "Verbessere Grammatik und Rechtschreibung, erfinde aber keine neuen Inhalte "
+                "und triff keine Annahmen. Gib nur den korrigierten Text zurück."
+            ),
+        },
+        {"role": "user", "content": text},
+    ]
+    try:
+        resp = await client.chat.completions.create(
+            model="gpt-4-1106-preview",
+            messages=messages,
+            temperature=0,
+        )
+        improved = resp.choices[0].message.content.strip()
+    except Exception as e:
+        logger.exception("OpenAI request failed: %s", e)
+        raise HTTPException(status_code=500, detail="AI request failed")
+    return {"text": improved}

--- a/api/main.py
+++ b/api/main.py
@@ -99,6 +99,12 @@ try:
 except Exception as e:
     print(f"⚠️ Fehler beim Einbinden von sprint_controller: {e}")
 
+try:
+    from controller.ai_controller import router as ai_router
+    app.include_router(ai_router)
+except Exception as e:
+    print(f"⚠️ Fehler beim Einbinden von ai_controller: {e}")
+
 def custom_openapi():
     if app.openapi_schema:
         return app.openapi_schema

--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -28,6 +28,11 @@ urlpatterns = [
     path("task/update/", views.update_task_details, name="update_task_details"),
     path("task/new/", views.task_create, name="task_create"),
     path("task/add_comment/", views.add_task_comment, name="task_add_comment"),
+    path(
+        "task/improve_description/",
+        views.improve_task_description,
+        name="task_improve_description",
+    ),
     path("task/view/<str:task_id>/", views.task_pageview, name="task_pageview"),
     path("person/", views.person_listview, name="person_liste"),
     path("person/new/", views.person_create, name="person_create"),

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -46,7 +46,10 @@
               <input class="form-control form-control-sm" type="text" name="betreff" value="{{ task.betreff }}">
             </div>
             <div class="mb-2">
-              <label class="form-label">Beschreibung</label>
+              <div class="d-flex justify-content-between align-items-center">
+                <label class="form-label mb-0">Beschreibung</label>
+                <button id="improveBtn" type="button" class="btn btn-sm btn-outline-secondary" title="Text korrigieren">🔍</button>
+              </div>
               <textarea class="form-control form-control-sm" name="beschreibung">{{ task.beschreibung }}</textarea>
             </div>
             <div class="mb-2">
@@ -334,6 +337,25 @@ commentForm.addEventListener('submit', e => {
       alert(d.error);
     }
   }).catch(()=>alert('Fehler beim Speichern des Kommentars'));
+});
+
+const improveBtn = document.getElementById('improveBtn');
+improveBtn.addEventListener('click', () => {
+  const textarea = form.elements['beschreibung'];
+  fetch('/task/improve_description/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-CSRFToken': getCookie('csrftoken'),
+    },
+    body: 'text=' + encodeURIComponent(textarea.value)
+  }).then(r => r.ok ? r.json() : Promise.reject()).then(d => {
+    if(d.text){
+      textarea.value = d.text;
+    } else if(d.error){
+      alert(d.error);
+    }
+  }).catch(()=>alert('Fehler bei KI-Anfrage'));
 });
 </script>
 {% endblock %}

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -11,6 +11,7 @@ from .tasks import (
     task_create,
     task_pageview,
     add_task_comment,
+    improve_task_description,
 )
 from .projects import (
     project_listview,

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -557,3 +557,30 @@ def add_task_comment(request):
 
 
     return JsonResponse({"error": "Ungültige Methode."}, status=405)
+
+
+@login_required
+@csrf_exempt
+def improve_task_description(request):
+    if request.method == "POST":
+        text = request.POST.get("text", "").strip()
+        if not text:
+            return JsonResponse({"error": "Kein Text."}, status=400)
+
+        res = requests.post(
+            f"{OTTO_API_URL}/ai/improve_description",
+            headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+            data=json.dumps({"text": text}),
+        )
+
+        if res.status_code == 200:
+            data = res.json()
+            return JsonResponse({"text": data.get("text", text)})
+
+        try:
+            detail = res.json().get("detail")
+        except Exception:
+            detail = None
+        return JsonResponse({"error": detail or "Fehler bei KI-Anfrage."}, status=res.status_code or 500)
+
+    return JsonResponse({"error": "Ungültige Methode."}, status=405)


### PR DESCRIPTION
## Summary
- add new `ai_controller` with `/ai/improve_description` endpoint
- wire controller in main API app
- expose `improve_task_description` view from Django and register URL
- update task detail page with magnifying glass button calling AI endpoint

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_b_683c09e9ee0483298b92cca65c18e5c8