### PR TITLE
Fix JS context injection in task detail page

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -6,7 +6,7 @@
     type: "task",
     name: "{{ task.betreff }}",
     id: "{{ task.id }}",
-    context: "{{ context_json|safe }}",
+    context: {{ context_json|safe }},
     gptFunctions: ["get_task_by_id"]
   }
 </script>


### PR DESCRIPTION
## Summary
- fix syntax error on task detail page by inserting JSON context without quotes

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683c0d8413fc8329a642a22e48aea09f