### PR TITLE
Generalize AI improvement button

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -42,13 +42,16 @@
         <div class="row">
           <div class="col-9">
             <div class="mb-2">
-              <label class="form-label">Betreff</label>
+              <div class="d-flex justify-content-between align-items-center">
+                <label class="form-label mb-0">Betreff</label>
+                <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="[name=betreff]" title="Text korrigieren">🤖</button>
+              </div>
               <input class="form-control form-control-sm" type="text" name="betreff" value="{{ task.betreff }}">
             </div>
             <div class="mb-2">
               <div class="d-flex justify-content-between align-items-center">
                 <label class="form-label mb-0">Beschreibung</label>
-                <button id="improveBtn" type="button" class="btn btn-sm btn-outline-secondary" title="Text korrigieren">🔍</button>
+                <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="[name=beschreibung]" title="Text korrigieren">🤖</button>
               </div>
               <textarea class="form-control form-control-sm" name="beschreibung">{{ task.beschreibung }}</textarea>
             </div>
@@ -171,7 +174,13 @@
           <form id="commentForm" class="mt-3" data-task-id="{{ task.id }}">
             {% csrf_token %}
             <input type="hidden" name="task_id" value="{{ task.id }}">
-            <textarea class="form-control form-control-sm mb-2" name="text" rows="2" placeholder="Kommentar..."></textarea>
+            <div class="mb-2">
+              <div class="d-flex justify-content-between align-items-center">
+                <label class="form-label mb-0" for="commentText">Kommentar</label>
+                <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="#commentText" title="Text korrigieren">🤖</button>
+              </div>
+              <textarea id="commentText" class="form-control form-control-sm" name="text" rows="2" placeholder="Kommentar..."></textarea>
+            </div>
             <div class="form-check mb-2">
               <input class="form-check-input" type="checkbox" value="1" id="sendEmail" name="send_email">
               <label class="form-check-label" for="sendEmail">Als E-Mail an Requester senden</label>
@@ -339,23 +348,30 @@ commentForm.addEventListener('submit', e => {
   }).catch(()=>alert('Fehler beim Speichern des Kommentars'));
 });
 
-const improveBtn = document.getElementById('improveBtn');
-improveBtn.addEventListener('click', () => {
-  const textarea = form.elements['beschreibung'];
-  fetch('/task/improve_description/', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'X-CSRFToken': getCookie('csrftoken'),
-    },
-    body: 'text=' + encodeURIComponent(textarea.value)
-  }).then(r => r.ok ? r.json() : Promise.reject()).then(d => {
-    if(d.text){
-      textarea.value = d.text;
-    } else if(d.error){
-      alert(d.error);
-    }
-  }).catch(()=>alert('Fehler bei KI-Anfrage'));
+document.querySelectorAll('.ai-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const field = document.querySelector(btn.dataset.target);
+    if(!field) return;
+    const isHtml = btn.dataset.html === '1';
+    if(isHtml && window.tinymce) tinymce.triggerSave();
+    const params = new URLSearchParams();
+    params.set('text', field.value);
+    if(isHtml) params.set('html', '1');
+    fetch('/task/improve_description/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-CSRFToken': getCookie('csrftoken'),
+      },
+      body: params.toString()
+    }).then(r => r.ok ? r.json() : Promise.reject()).then(d => {
+      if(d.text){
+        field.value = d.text;
+      } else if(d.error){
+        alert(d.error);
+      }
+    }).catch(()=>alert('Fehler bei KI-Anfrage'));
+  });
 });
 </script>
 {% endblock %}

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -564,13 +564,18 @@ def add_task_comment(request):
 def improve_task_description(request):
     if request.method == "POST":
         text = request.POST.get("text", "").strip()
+        html = request.POST.get("html") == "1"
         if not text:
             return JsonResponse({"error": "Kein Text."}, status=400)
+
+        payload = {"text": text}
+        if html:
+            payload["html"] = True
 
         res = requests.post(
             f"{OTTO_API_URL}/ai/improve_description",
             headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
-            data=json.dumps({"text": text}),
+            data=json.dumps(payload),
         )
 
         if res.status_code == 200:


### PR DESCRIPTION
## Summary
- allow AI endpoint to handle optional HTML content
- extend view to pass HTML flag
- add AI buttons for Betreff, Beschreibung and Kommentare
- simplify client JS to handle multiple AI buttons with optional HTML support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c14b64da48329b7942a90c29c75e0