### PR TITLE
Add AI text improvement to project view

### DIFF
--- a/otto-ui/config/urls.py
+++ b/otto-ui/config/urls.py
@@ -30,8 +30,13 @@ urlpatterns = [
     path("task/add_comment/", views.add_task_comment, name="task_add_comment"),
     path(
         "task/improve_description/",
-        views.improve_task_description,
+        views.improve_description,
         name="task_improve_description",
+    ),
+    path(
+        "improve_description/",
+        views.improve_description,
+        name="improve_description",
     ),
     path("task/view/<str:task_id>/", views.task_pageview, name="task_pageview"),
     path("person/", views.person_listview, name="person_liste"),

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -42,11 +42,17 @@
             <div class="row">
                 <div class="col-9">
                     <div class="mb-3">
-                        <label class="form-label">Name</label>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <label class="form-label mb-0">Name</label>
+                            <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="[name=name]" title="Text korrigieren">🤖</button>
+                        </div>
                         <input type="text" name="name" class="form-control" value="{{ projekt.name }}">
                     </div>
                     <div class="mb-3">
-                        <label class="form-label">Beschreibung</label>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <label class="form-label mb-0">Beschreibung</label>
+                            <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="#editor" data-html="1" title="Text korrigieren">🤖</button>
+                        </div>
                         <textarea id="editor" name="beschreibung" class="form-control">{{ projekt.beschreibung|safe }}</textarea>
                     </div>
                     <div class="mb-4">
@@ -56,7 +62,10 @@
                 </div>
                 <div class="col-3">
                     <div class="mb-3">
-                        <label class="form-label">Short</label>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <label class="form-label mb-0">Short</label>
+                            <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="[name=short]" title="Text korrigieren">🤖</button>
+                        </div>
                         <input type="text" name="short" class="form-control" value="{{ projekt.short }}">
                     </div>
                     <div class="mb-3">
@@ -232,7 +241,10 @@
 <form id="taskForm" class="row g-2">
   {% csrf_token %}
   <div class="col-12 col-md-4">
-    <input type="text" name="betreff" class="form-control" placeholder="Betreff" required>
+    <div class="input-group input-group-sm">
+      <input type="text" name="betreff" class="form-control" placeholder="Betreff" required>
+      <button type="button" class="btn btn-outline-secondary ai-btn" data-target="#taskForm [name=betreff]" title="Text korrigieren">🤖</button>
+    </div>
   </div>
   <div class="col-6 col-md-2">
     <input type="date" name="termin" class="form-control">
@@ -533,7 +545,7 @@ if (showDoneCheckbox) {
   showDoneCheckbox.addEventListener('change', applyShowDone);
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('DOMContentLoaded', () => {
   // Merke zuletzt genutzten Tab in localStorage
   const tabKey = 'projectTab_' + window.ottoContext.id;
   const savedTab = localStorage.getItem(tabKey);
@@ -550,7 +562,33 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem(tabKey, target);
     });
   });
-  applyShowDone();
-});
+    applyShowDone();
+  });
+
+  document.querySelectorAll('.ai-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const field = document.querySelector(btn.dataset.target);
+      if(!field) return;
+      const isHtml = btn.dataset.html === '1';
+      if(isHtml && window.tinymce) tinymce.triggerSave();
+      const params = new URLSearchParams();
+      params.set('text', field.value);
+      if(isHtml) params.set('html', '1');
+      fetch('/improve_description/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-CSRFToken': getCookie('csrftoken'),
+        },
+        body: params.toString()
+      }).then(r => r.ok ? r.json() : Promise.reject()).then(d => {
+        if(d.text){
+          field.value = d.text;
+        } else if(d.error){
+          alert(d.error);
+        }
+      }).catch(()=>alert('Fehler bei KI-Anfrage'));
+    });
+  });
 </script>
 {% endblock %}

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -357,7 +357,7 @@ document.querySelectorAll('.ai-btn').forEach(btn => {
     const params = new URLSearchParams();
     params.set('text', field.value);
     if(isHtml) params.set('html', '1');
-    fetch('/task/improve_description/', {
+    fetch('/improve_description/', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/otto-ui/core/views/__init__.py
+++ b/otto-ui/core/views/__init__.py
@@ -13,6 +13,7 @@ from .tasks import (
     add_task_comment,
     improve_task_description,
 )
+from .ai import improve_description
 from .projects import (
     project_listview,
     project_detailview,

--- a/otto-ui/core/views/ai.py
+++ b/otto-ui/core/views/ai.py
@@ -1,0 +1,43 @@
+import os
+import json
+import requests
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from .helpers import login_required
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OTTO_API_KEY = os.getenv("OTTO_API_KEY")
+OTTO_API_URL = os.getenv("OTTO_API_URL")
+
+
+@login_required
+@csrf_exempt
+def improve_description(request):
+    if request.method != "POST":
+        return JsonResponse({"error": "Ung\u00fcltige Methode."}, status=405)
+
+    text = request.POST.get("text", "").strip()
+    html = request.POST.get("html") == "1"
+    if not text:
+        return JsonResponse({"error": "Kein Text."}, status=400)
+
+    payload = {"text": text}
+    if html:
+        payload["html"] = True
+
+    res = requests.post(
+        f"{OTTO_API_URL}/ai/improve_description",
+        headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
+        data=json.dumps(payload),
+    )
+    if res.status_code == 200:
+        data = res.json()
+        return JsonResponse({"text": data.get("text", text)})
+
+    try:
+        detail = res.json().get("detail")
+    except Exception:
+        detail = None
+    return JsonResponse({"error": detail or "Fehler bei KI-Anfrage."}, status=res.status_code or 500)

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -7,6 +7,7 @@ from .helpers import login_required
 from django.views.decorators.csrf import csrf_exempt
 from django.template.loader import render_to_string
 from core.const import prio_liste, status_liste, typ_liste
+from .ai import improve_description
 import os
 from dotenv import load_dotenv
 
@@ -562,30 +563,4 @@ def add_task_comment(request):
 @login_required
 @csrf_exempt
 def improve_task_description(request):
-    if request.method == "POST":
-        text = request.POST.get("text", "").strip()
-        html = request.POST.get("html") == "1"
-        if not text:
-            return JsonResponse({"error": "Kein Text."}, status=400)
-
-        payload = {"text": text}
-        if html:
-            payload["html"] = True
-
-        res = requests.post(
-            f"{OTTO_API_URL}/ai/improve_description",
-            headers={"x-api-key": OTTO_API_KEY, "Content-Type": "application/json"},
-            data=json.dumps(payload),
-        )
-
-        if res.status_code == 200:
-            data = res.json()
-            return JsonResponse({"text": data.get("text", text)})
-
-        try:
-            detail = res.json().get("detail")
-        except Exception:
-            detail = None
-        return JsonResponse({"error": detail or "Fehler bei KI-Anfrage."}, status=res.status_code or 500)
-
-    return JsonResponse({"error": "Ungültige Methode."}, status=405)
+    return improve_description(request)


### PR DESCRIPTION
## Summary
- create new `improve_description` view for generic AI text corrections
- expose `/improve_description/` endpoint and keep task route
- refactor task view to reuse new improvement function
- add AI helper buttons in project detail view
- use new endpoint in task detail page

## Testing
- `python -m py_compile otto-ui/core/views/ai.py otto-ui/core/views/tasks.py otto-ui/config/urls.py otto-ui/core/views/__init__.py`

------
https://chatgpt.com/codex/tasks/task_b_683c1ba8be608329b7da4d41c77d9254