### PR TITLE
Improve chat sidebar toggle

### DIFF
--- a/otto-ui/core/templates/base.html
+++ b/otto-ui/core/templates/base.html
@@ -150,11 +150,31 @@
                 toast.show();
             }
         });
-    </script>
-    <script>
-        document.getElementById('toggle-chat-sidebar').addEventListener('click', function() {
-            const sidebar = document.querySelector('.sidebar-right');
-            sidebar.classList.toggle('d-none');
+
+        document.addEventListener('DOMContentLoaded', function() {
+            const toggleBtn = document.getElementById('toggle-chat-sidebar');
+
+            function updateSidebar(initial) {
+                const sidebar = document.querySelector('.sidebar-right');
+                if (!sidebar) return;
+                if (initial) {
+                    const stored = localStorage.getItem('chatSidebarHidden');
+                    if (stored === 'true') {
+                        sidebar.classList.add('d-none');
+                    }
+                } else {
+                    const hidden = sidebar.classList.toggle('d-none');
+                    localStorage.setItem('chatSidebarHidden', hidden);
+                }
+            }
+
+            updateSidebar(true);
+
+            if (toggleBtn) {
+                toggleBtn.addEventListener('click', function() {
+                    updateSidebar(false);
+                });
+            }
         });
     </script>
     <script type="module" src="{% static 'otto_chat/assets/index-CBL3uiBv.js' %}"></script>


### PR DESCRIPTION
## Summary
- update JS in `base.html` to persist sidebar state in localStorage
- restore sidebar on load and ensure toggle always works

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_683c515405848329bb922759b84166f1