### PR TITLE
Fix kanban column collapsing

### DIFF
--- a/otto-ui/core/static/css/kanban.css
+++ b/otto-ui/core/static/css/kanban.css
@@ -28,6 +28,13 @@
   display: none;
 }
 
+.kanban-column.collapsed {
+  flex: 0 0 auto;
+  width: auto;
+  white-space: nowrap;
+  overflow-y: hidden;
+}
+
 .toggle-column {
   padding: 0;
   margin-right: 0.25rem;


### PR DESCRIPTION
## Summary
- adjust collapsed kanban column width so it really collapses horizontally

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683c531d93488329a8300a8817cd209c