### PR TITLE
Add Umsetzung field for tasks

### DIFF
--- a/api/model/task.py
+++ b/api/model/task.py
@@ -6,6 +6,7 @@ class Task(BaseModel):
     tid: Optional[int] = None
     betreff: str
     beschreibung: Optional[str] = ""
+    umsetzung: Optional[str] = ""
     tasktype: Optional[str] = Field(None, description="Typ der Aufgabe, z.B. 'Aufgabe', 'Feature', 'Bug', 'Ticket', 'Requirement', 'Sonstiges'")
     person_id: str = Field(..., description="ID der verantwortlichen Person (personen.id)")
     requester_id: Optional[str] = Field(None, description="ID der anfordernden Person (personen.id)")

--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -56,6 +56,13 @@
               <textarea class="form-control form-control-sm" name="beschreibung">{{ task.beschreibung }}</textarea>
             </div>
             <div class="mb-2">
+              <div class="d-flex justify-content-between align-items-center">
+                <label class="form-label mb-0">Umsetzung</label>
+                <button type="button" class="btn btn-sm btn-outline-secondary ai-btn" data-target="[name=umsetzung]" title="Text korrigieren">🤖</button>
+              </div>
+              <textarea class="form-control form-control-sm" name="umsetzung">{{ task.umsetzung }}</textarea>
+            </div>
+            <div class="mb-2">
               <label class="form-label">Projekt</label>
               <select class="form-select form-select-sm" name="project_id">
                 <option value="">-- Kein Projekt --</option>

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -250,6 +250,7 @@ def project_create_task(request):
         json={
             "betreff": data["betreff"],
             "beschreibung": "",
+            "umsetzung": "",
             "zuständig": data.get("zuständig", "Otto"),
             "person_id": data.get("person_id"),
             "requester_id": data.get("requester_id"),

--- a/otto-ui/core/views/sprints.py
+++ b/otto-ui/core/views/sprints.py
@@ -168,6 +168,7 @@ def sprint_create_task(request):
         json={
             "betreff": data["betreff"],
             "beschreibung": "",
+            "umsetzung": "",
             "zuständig": data.get("zuständig", "Otto"),
             "person_id": data.get("person_id"),
             "requester_id": data.get("requester_id"),

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -342,6 +342,7 @@ def update_task_details(request):
         task = get_res.json()
         task["betreff"] = request.POST.get("betreff")
         task["beschreibung"] = request.POST.get("beschreibung")
+        task["umsetzung"] = request.POST.get("umsetzung")
         task["tasktype"] = request.POST.get("tasktype")
         task["status"] = request.POST.get("status")
         task["prio"] = request.POST.get("prio")


### PR DESCRIPTION
## Summary
- add `umsetzung` attribute in the backend Task model
- store and edit `umsetzung` in task views
- include the new field when creating tasks from projects or sprints
- display the new textarea with Improve AI button on the task detail page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683c58410f8c832981f4b4d181b8c45c