### PR TITLE
Auto-link URLs in comments

### DIFF
--- a/otto-ui/core/templates/components/comment_item.html
+++ b/otto-ui/core/templates/components/comment_item.html
@@ -9,5 +9,5 @@
       <a href="/message/{{ c.message_id }}/" class="ms-1">📧</a>
     {% endif %}
   </div>
-  <div>{{ c.text|linebreaksbr }}</div>
+  <div>{{ c.text|urlize|linebreaksbr }}</div>
 </div>


### PR DESCRIPTION
## Summary
- auto-convert URLs in comments to clickable links

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_683c6277143883298176b3b5d764177f