### PR TITLE
Add project_id to OttoChat prompt

### DIFF
--- a/otto-ui/otto-chat/src/ChatOtto.jsx
+++ b/otto-ui/otto-chat/src/ChatOtto.jsx
@@ -32,8 +32,9 @@ export default function ChatOtto() {
 
   useEffect(() => {
     const ctxInfo = window.ottoContext
+    const projectInfo = ctxInfo?.project_id ? `, project_id: ${ctxInfo.project_id}` : ''
     const promptContext = ctxInfo
-      ? `${ctxInfo.type} „${ctxInfo.name}“ (ID: ${ctxInfo.id}) - Funktionen: ${ctxInfo.gptFunctions.join(", ")}`
+      ? `${ctxInfo.type} „${ctxInfo.name}“ (ID: ${ctxInfo.id}${projectInfo}) - Funktionen: ${ctxInfo.gptFunctions.join(", ")}`
       : context
 
     const availableFunctions = ctxInfo?.gptFunctions?.length
@@ -62,8 +63,9 @@ export default function ChatOtto() {
     if (!input.trim()) return
 
     const ctxInfo = window.ottoContext
+    const projectInfoSend = ctxInfo?.project_id ? `, project_id: ${ctxInfo.project_id}` : ''
     const promptContext = ctxInfo
-      ? `${ctxInfo.type} „${ctxInfo.name}“ (ID: ${ctxInfo.id}) - Funktionen: ${ctxInfo.gptFunctions.join(", ")}`
+      ? `${ctxInfo.type} „${ctxInfo.name}“ (ID: ${ctxInfo.id}${projectInfoSend}) - Funktionen: ${ctxInfo.gptFunctions.join(", ")}`
       : context
 
     const extraContext = ctxInfo?.context ? ` Kontext: ${ctxInfo.context}` : ""


### PR DESCRIPTION
## Summary
- show `project_id` from `ottoContext` in the chat prompt

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_683c669a58888329b09905f007c0e784