### PR TITLE
Fill requester_id in message context

### DIFF
--- a/otto-ui/core/templates/core/message_listview.html
+++ b/otto-ui/core/templates/core/message_listview.html
@@ -7,6 +7,7 @@
     name: "{{ selected.subject|default:''|escapejs }}",
     id: "{{ selected.id|default:'' }}",
     project_id: "{{ selected.project_id|default_if_none:'' }}",
+    requester_id: "{{ selected.requester_id|default_if_none:'' }}",
     context: "{{ selected.message|default:''|escapejs }}",
     gptFunctions: []
   }

--- a/otto-ui/core/views/messages.py
+++ b/otto-ui/core/views/messages.py
@@ -64,6 +64,18 @@ def message_listview(request):
         )
         if res_det.status_code == 200:
             selected = res_det.json()
+            # try to determine requester_id based on sender address
+            sender_addr = (selected.get("sender") or selected.get("from") or "").lower()
+            if sender_addr:
+                personen_res = requests.get(
+                    f"{OTTO_API_URL}/personen",
+                    headers={"x-api-key": OTTO_API_KEY},
+                )
+                if personen_res.status_code == 200:
+                    for p in personen_res.json():
+                        if p.get("email", "").lower() == sender_addr:
+                            selected["requester_id"] = p.get("id")
+                            break
             sim_res = requests.get(
                 f"{OTTO_API_URL}/messages/{selected_id}/similar_tasks",
                 headers={"x-api-key": OTTO_API_KEY},


### PR DESCRIPTION
## Summary
- infer `requester_id` from sender email when a message is opened
- expose the ID through `window.ottoContext` on the message list page

## Testing
- `python -m py_compile otto-ui/core/views/messages.py`

------
https://chatgpt.com/codex/tasks/task_b_683c72d9d6ac8329b7fe54114450f8f6