### PR TITLE
Fix URL encoding for task creation

### DIFF
--- a/otto-ui/core/static/otto_extension.js
+++ b/otto-ui/core/static/otto_extension.js
@@ -15,11 +15,16 @@ window.ottoUI.openProjectForm = function(values) {
 
 window.ottoUI.openTaskForm = function(values) {
   try {
-    var params = new URLSearchParams(values || {});
+    var params = Object.keys(values || {})
+      .map(function(key) {
+        var v = values[key];
+        return encodeURIComponent(key) + "=" + encodeURIComponent(v);
+      })
+      .join("&");
     if (window.ottoContext && window.ottoContext.id) {
-      params.set('project_id', window.ottoContext.id);
+      params += (params ? '&' : '') + 'project_id=' + encodeURIComponent(window.ottoContext.id);
     }
-    window.location.href = '/task/new/' + (params.toString() ? ('?' + params.toString()) : '');
+    window.location.href = '/task/new/' + (params ? ('?' + params) : '');
   } catch (e) {
     console.error('openTaskForm failed', e);
   }


### PR DESCRIPTION
## Summary
- ensure openTaskForm correctly encodes values using `encodeURIComponent`

## Testing
- `pytest -q`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c772b497c8329be9d737c166cb878