### PR TITLE
Fix save path on task detail

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -266,7 +266,7 @@ function saveTask() {
   }
 });
   console.log('Task-Daten:', data);
-  return fetch('', {
+  return fetch(location.pathname, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- ensure saveTask posts to the current path without query parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ca5c4b3048329be6ba83b4194587a