### PR TITLE
Fix drag and drop moving entire columns

### DIFF
--- a/otto-ui/core/templates/core/task_kanban.html
+++ b/otto-ui/core/templates/core/task_kanban.html
@@ -146,13 +146,13 @@
       });
     }
 
-    document.querySelectorAll('.kanban-column').forEach(function(col){
+    document.querySelectorAll('.kanban-column-body').forEach(function(col){
       new Sortable(col, {
         group: 'tasks',
         animation: 150,
         onEnd: function(evt){
           const taskId = evt.item.dataset.taskId;
-          const newStatus = evt.to.dataset.status;
+          const newStatus = evt.to.closest('.kanban-column').dataset.status;
           fetch('/task/update_status/', {
             method: 'POST',
             headers: {'HX-Request': 'true'},

--- a/otto-ui/core/templates/core/task_weekboard.html
+++ b/otto-ui/core/templates/core/task_weekboard.html
@@ -64,13 +64,13 @@
       window.location = url.toString();
     });
 
-    document.querySelectorAll('.kanban-column').forEach(function(col){
+    document.querySelectorAll('.kanban-column-body').forEach(function(col){
       new Sortable(col, {
         group: 'tasks',
         animation: 150,
         onEnd: function(evt){
           const taskId = evt.item.dataset.taskId;
-          const newDate = evt.to.dataset.date;
+          const newDate = evt.to.closest('.kanban-column').dataset.date;
           fetch(`/task/view/${taskId}/`, {
             method: 'POST',
             headers: { 'Content-Type':'application/json' },


### PR DESCRIPTION
## Summary
- fix Sortable containers on week and kanban views so only individual tasks move

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68459efb57b083278ccc5047aaf297f7