### PR TITLE
Show project, effort and status on weekview cards

### DIFF
--- a/otto-ui/core/templates/core/task_weekboard.html
+++ b/otto-ui/core/templates/core/task_weekboard.html
@@ -39,7 +39,14 @@
         <div class="card mb-2" draggable="true" data-task-id="{{ task.id }}">
           <div class="card-body p-2">
             <div><strong>{{ task.betreff }}</strong></div>
+            {% if task.project_name %}
+            <div><small>📂 {{ task.project_name }}</small></div>
+            {% endif %}
             <div><small>📅 {{ task.termin_formatiert }}</small></div>
+            {% if task.aufwand %}
+            <div><small>⏱ {{ task.aufwand }}h</small></div>
+            {% endif %}
+            <div><small>{{ task.status }}</small></div>
           </div>
         </div>
         {% endfor %}

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -353,6 +353,12 @@ def task_week_view(request):
 
     res = requests.get(f"{OTTO_API_URL}/tasks", headers={"x-api-key": OTTO_API_KEY})
     tasks = res.json() if res.status_code == 200 else []
+
+    # Projekte laden, um Namen zuordnen zu können
+    projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
+    projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    projekt_map = {p.get("id"): p.get("name") for p in projekte}
+
     personen, agenten = load_person_lists()
 
     days = []
@@ -385,6 +391,8 @@ def task_week_view(request):
                 key = disp.isoformat()
                 if key in per_tasks:
                     t["termin_formatiert"] = termin_dt.strftime("%d.%m.%Y")
+                    pid = t.get("project_id")
+                    t["project_name"] = projekt_map.get(pid, "") if pid else ""
                     per_tasks[key].append(t)
         if any(per_tasks[d["iso"]] for d in days):
             board.append({"id": p.get("id"), "name": p.get("name"), "tasks": per_tasks})


### PR DESCRIPTION
## Summary
- fetch projects when building week board context
- display project, effort and status in week board cards

## Testing
- `python -m py_compile otto-ui/core/views/tasks.py`
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6845a07622e88327a86b6c21d05584a8