### PR TITLE
Fix empty day drop zone

### DIFF
--- a/otto-ui/core/static/css/kanban.css
+++ b/otto-ui/core/static/css/kanban.css
@@ -16,6 +16,9 @@
   padding: 0.5rem;
   border-radius: 4px;
 }
+.kanban-column-body {
+  min-height: 3rem;
+}
 .kanban-column-header {
   font-weight: bold;
   margin-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- ensure `.kanban-column-body` provides space when no tasks exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a4c4fa4c8327b3dd468fa7680cba