### PR TITLE
Remember open accordion and show task count

### DIFF
--- a/otto-ui/core/templates/core/task_weekboard.html
+++ b/otto-ui/core/templates/core/task_weekboard.html
@@ -33,7 +33,7 @@
   <div class="accordion-item">
     <h2 class="accordion-header" id="heading{{ person.id }}">
       <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{ person.id }}" aria-expanded="false" aria-controls="collapse{{ person.id }}">
-        {{ person.name }}
+        {{ person.name }} <span class="badge bg-secondary ms-2">{{ person.count }}</span>
       </button>
     </h2>
     <div id="collapse{{ person.id }}" class="accordion-collapse collapse" aria-labelledby="heading{{ person.id }}" data-bs-parent="#personAccordion">
@@ -82,6 +82,21 @@
       }
       window.location = url.toString();
     });
+
+    document.querySelectorAll('#personAccordion .accordion-button').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        const target = btn.getAttribute('data-bs-target');
+        if (target) localStorage.setItem('openAccordion', target);
+      });
+    });
+
+    const saved = localStorage.getItem('openAccordion');
+    if (saved) {
+      const el = document.querySelector(saved);
+      if (el) {
+        new bootstrap.Collapse(el, {toggle: false}).show();
+      }
+    }
 
     document.querySelectorAll('.kanban-column-body').forEach(function(col){
       new Sortable(col, {

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -372,6 +372,7 @@ def task_week_view(request):
     board = []
     for p in agenten:
         per_tasks = {day["iso"]: [] for day in days}
+        total_count = 0
         for t in tasks:
             if t.get("person_id") != p.get("id"):
                 continue
@@ -394,8 +395,14 @@ def task_week_view(request):
                     pid = t.get("project_id")
                     t["project_name"] = projekt_map.get(pid, "") if pid else ""
                     per_tasks[key].append(t)
+                    total_count += 1
         if any(per_tasks[d["iso"]] for d in days):
-            board.append({"id": p.get("id"), "name": p.get("name"), "tasks": per_tasks})
+            board.append({
+                "id": p.get("id"),
+                "name": p.get("name"),
+                "tasks": per_tasks,
+                "count": total_count,
+            })
 
     prev_week = (start - timedelta(days=7)).strftime("%G-W%V")
     next_week = (start + timedelta(days=7)).strftime("%G-W%V")


### PR DESCRIPTION
## Summary
- show open task count next to each person
- remember which accordion panel was last open

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a6b0166883279dae9aa7250231e8