### PR TITLE
Remove closed and ongoing columns from Kanban

### DIFF
--- a/otto-ui/core/templates/core/task_kanban.html
+++ b/otto-ui/core/templates/core/task_kanban.html
@@ -43,10 +43,6 @@
       <input class="form-check-input" type="checkbox" id="kanban-without-project">
       <label class="form-check-label" for="kanban-without-project">Ohne Projekt</label>
     </div>
-    <div class="col-sm-2 form-check">
-      <input class="form-check-input" type="checkbox" id="toggle-completed" checked>
-      <label class="form-check-label" for="toggle-completed">Abgeschlossen anzeigen</label>
-    </div>
   </div>
   <div class="kanban-board">
   {% for status,tasks in grouped_list %}
@@ -136,15 +132,6 @@
       }
     });
 
-    const toggleCompleted = document.getElementById('toggle-completed');
-    if (toggleCompleted) {
-      toggleCompleted.addEventListener('change', function(e) {
-        const col = document.querySelector('.kanban-column[data-status="✅ abgeschlossen"]');
-        if (col) {
-          col.style.display = e.target.checked ? '' : 'none';
-        }
-      });
-    }
 
     document.querySelectorAll('.kanban-column-body').forEach(function(col){
       new Sortable(col, {

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -190,9 +190,12 @@ def task_kanban_view(request):
     sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     sprint_map = {s.get("id"): s.get("name") for s in sprints}
 
-    grouped = {status: [] for status in status_liste}
+    kanban_statuses = [s for s in status_liste if s not in ("✅ abgeschlossen", "📦 laufend")]
+    grouped = {status: [] for status in kanban_statuses}
     for t in tasks:
         status = t.get("status") or status_liste[0]
+        if status in ("✅ abgeschlossen", "📦 laufend"):
+            continue
         if status not in grouped:
             grouped[status] = []
         termin = t.get("termin")
@@ -209,11 +212,11 @@ def task_kanban_view(request):
     for lst in grouped.values():
         lst.sort(key=lambda x: x["termin_dt"] or datetime.max)
 
-    grouped_list = [(status, grouped.get(status, [])) for status in status_liste]
+    grouped_list = [(status, grouped.get(status, [])) for status in kanban_statuses]
 
     context = {
         "grouped_list": grouped_list,
-        "status_liste": status_liste,
+        "status_liste": kanban_statuses,
         "agenten": agenten,
         "projekte": projekte,
         "sprints": sprints,


### PR DESCRIPTION
## Summary
- filter out `✅ abgeschlossen` and `📦 laufend` tasks in Kanban view
- drop completed-column toggle UI

## Testing
- `python -m py_compile otto-ui/core/views/tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e12e781c8327b60676d033f5dece