### PR TITLE
Add project links to task board views

### DIFF
--- a/otto-ui/core/templates/core/task_kanban.html
+++ b/otto-ui/core/templates/core/task_kanban.html
@@ -57,6 +57,9 @@
       <div class="card-body p-2">
         <div><strong><a href="/task/view/{{ task.id }}/">{{ task.betreff }}</a></strong></div>
         <div><small>👤 {{ task.person_name }}</small></div>
+        {% if task.project_id %}
+        <div><small>📂 <a href="/project/{{ task.project_id }}/">{{ task.project_name }}</a></small></div>
+        {% endif %}
         <div><small>📅 {{ task.termin_formatiert }}</small></div>
         {% if task.sprint_name %}
         <div><small>🏃 {{ task.sprint_name }}</small></div>

--- a/otto-ui/core/templates/core/task_weekboard.html
+++ b/otto-ui/core/templates/core/task_weekboard.html
@@ -47,8 +47,8 @@
               <div class="card mb-2" draggable="true" data-task-id="{{ task.id }}">
                 <div class="card-body p-2">
                   <div><strong><a href="/task/view/{{ task.id }}/">{{ task.betreff }}</a></strong></div>
-                  {% if task.project_name %}
-                  <div><small>📂 {{ task.project_name }}</small></div>
+                  {% if task.project_id %}
+                  <div><small>📂 <a href="/project/{{ task.project_id }}/">{{ task.project_name }}</a></small></div>
                   {% endif %}
                   <div><small>📅 {{ task.termin_formatiert }}</small></div>
                   {% if task.aufwand %}

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -186,6 +186,7 @@ def task_kanban_view(request):
 
     projekte_res = requests.get(f"{OTTO_API_URL}/projekte", headers={"x-api-key": OTTO_API_KEY})
     projekte = projekte_res.json() if projekte_res.status_code == 200 else []
+    projekt_map = {p.get("id"): p.get("name") for p in projekte}
     sprints_res = requests.get(f"{OTTO_API_URL}/sprints", headers={"x-api-key": OTTO_API_KEY})
     sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     sprint_map = {s.get("id"): s.get("name") for s in sprints}
@@ -207,6 +208,8 @@ def task_kanban_view(request):
         t["termin_formatiert"] = termin_dt.strftime("%d.%m.%Y") if termin_dt else "-"
         t["person_name"] = personen_map.get(t.get("person_id"), "-")
         t["sprint_name"] = sprint_map.get(t.get("sprint_id"))
+        pid = t.get("project_id")
+        t["project_name"] = projekt_map.get(pid, "") if pid else ""
         grouped[status].append(t)
 
     for lst in grouped.values():


### PR DESCRIPTION
## Summary
- show project name links in Kanban task cards
- link project name in weekboard view
- include project names when generating Kanban tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e2c42848832799c226291bf53c58