### PR TITLE
Improve GitHub repo dropdown behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,17 @@ Ein flexibles, KI-gestütztes System zur Erkennung, Strukturierung und Weiterver
 - Berechtigungs- und Kontextsicherheitsmodell
 - Progressive Web App / Offlinefähigkeit
 
+## GitHub-Integration
+
+Damit im Projektformular GitHub-Repositories auswählbar sind, müssen folgende
+Umgebungsvariablen gesetzt sein (z.B. in einer `.env` Datei):
+
+```
+GitHub_API_URL=https://api.github.com
+GitHub_ORGNAME=<deine Organisation>
+GitHub_API_KEY=<persönlicher Access Token>
+```
+
+Ohne diese Einstellungen bleibt das Dropdown leer.
+
 Christian Angermeier, Mai 2025

--- a/otto-ui/core/templates/core/project_detailview.html
+++ b/otto-ui/core/templates/core/project_detailview.html
@@ -130,6 +130,9 @@
                                 <option value="{{ repo.id }}" {% if repo.id == projekt.github_repo_id %}selected{% endif %}>{{ repo.name }}</option>
                             {% endfor %}
                         </select>
+                        {% if github_repos|length == 0 %}
+                        <div class="alert alert-warning mt-2">Keine GitHub-Repositories geladen. Prüfe die API-Konfiguration.</div>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/otto-ui/core/views/projects.py
+++ b/otto-ui/core/views/projects.py
@@ -43,9 +43,13 @@ def load_github_repos():
     }
     url = f"{GITHUB_API_URL}/orgs/{GITHUB_ORGNAME}/repos"
     try:
-        res = requests.get(url, headers=headers)
-        return res.json() if res.status_code == 200 else []
-    except Exception:
+        res = requests.get(url, headers=headers, timeout=5)
+        if res.status_code != 200:
+            logger.error("GitHub API returned %s: %s", res.status_code, res.text)
+            return []
+        return res.json()
+    except requests.RequestException as e:
+        logger.error("Failed to load GitHub repos: %s", e)
         return []
 
 


### PR DESCRIPTION
## Summary
- show an alert in the project form when no GitHub repos are loaded
- log errors when fetching repos fails
- document required GitHub settings in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea0065e0832781272361b1bd79b6