### PR TITLE
Add test notification email templates

### DIFF
--- a/otto-ui/core/templates/emails/task/testbenachrichtigung_de.html
+++ b/otto-ui/core/templates/emails/task/testbenachrichtigung_de.html
@@ -1,0 +1,17 @@
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <p>Hallo zusammen,</p>
+
+    <p>für {{ projekt.name }} steht ab sofort die Testphase an. Der Testzeitraum beträgt <strong>2 Wochen</strong> ab heute. Wir bitten euch, innerhalb dieses Zeitraums die notwendigen Tests durchzuführen.</p>
+
+    <p><strong>Hinweise zum Testen:</strong><br>
+    {{ task.umsetzung|safe }}</p>
+
+    <p>Ein finaler Update-Termin wird bekannt gegeben, sobald die Testergebnisse vorliegen.</p>
+
+    <p>Bei Problemen, Fragen oder Anregungen wendet euch bitte an {{ requester.name }} (<a href="mailto:{{ requester.email }}">{{ requester.email }}</a>).</p>
+
+    <p>Vielen Dank!<br><br>
+    Christian ∞</p>
+  </body>
+</html>

--- a/otto-ui/core/templates/emails/task/testbenachrichtigung_en.html
+++ b/otto-ui/core/templates/emails/task/testbenachrichtigung_en.html
@@ -1,0 +1,17 @@
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <p>Hello everyone,</p>
+
+    <p>The test phase for {{ projekt.name }} starts now. The testing period lasts for <strong>2 weeks</strong> from today. Please complete the necessary tests within this timeframe.</p>
+
+    <p><strong>Testing Guidelines:</strong><br>
+    {{ task.umsetzung|safe }}</p>
+
+    <p>A final update date will be announced once the test results are available.</p>
+
+    <p>If you have any issues, questions, or suggestions, please contact {{ requester.name }} (<a href="mailto:{{ requester.email }}">{{ requester.email }}</a>).</p>
+
+    <p>Thanks a lot!<br>
+    Christian ∞</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add DE/EN templates for test notification emails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e36b39648327ad8cdc2354929775