### PR TITLE
Add email template dropdown for tasks

### DIFF
--- a/otto-ui/core/templates/core/task_detailpage.html
+++ b/otto-ui/core/templates/core/task_detailpage.html
@@ -24,6 +24,14 @@
           <button id="saveCloseBtn" type="button" class="btn btn-outline-secondary">💾 Speichern &amp; Schließen</button>
         </div>
         <div class="btn-group me-2" role="group">
+          <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">📧 Vorlage</button>
+          <ul class="dropdown-menu">
+            {% for t in email_templates %}
+            <li><a class="dropdown-item" href="/message/new/?template={{ t }}&task_id={{ task.id }}">{{ t }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+        <div class="btn-group me-2" role="group">
           <button id="doneBtn" type="button" class="btn btn-outline-success">✅ Erledigt</button>
         </div>
         <div class="btn-group" role="group">

--- a/otto-ui/core/views/tasks.py
+++ b/otto-ui/core/views/tasks.py
@@ -597,6 +597,8 @@ def task_pageview(request, task_id):
     sprints = sprints_res.json() if sprints_res.status_code == 200 else []
     meetings_res = requests.get(f"{OTTO_API_URL}/meetings", headers={"x-api-key": OTTO_API_KEY})
     meetings = meetings_res.json() if meetings_res.status_code == 200 else []
+    templates_dir = os.path.join(os.path.dirname(__file__), '../templates/emails/task')
+    email_templates = [f[:-5] for f in os.listdir(templates_dir) if f.endswith('.html')]
     context_res = requests.get(
         f"{OTTO_API_URL}/context/aufgabe/{task_id}",
         headers={"x-api-key": OTTO_API_KEY},
@@ -629,6 +631,7 @@ def task_pageview(request, task_id):
         "personen_map": personen_map,
         "context_json": json.dumps(task_context),
         "context_text": context_text,
+        "email_templates": email_templates,
     })
 
 


### PR DESCRIPTION
## Summary
- enable sending task templates via `/message/new/`
- list available task templates in task detail view

## Testing
- `python -m py_compile otto-ui/core/views/messages.py otto-ui/core/views/tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_6847e51bfa408327b5ad3dc5db68262b